### PR TITLE
Fix #21 "Windows Build - _S_ISDIR unresolved"

### DIFF
--- a/lib/libconfig.c
+++ b/lib/libconfig.c
@@ -52,6 +52,10 @@
 #define _new(T) (T *)calloc(1, sizeof(T)) /* zeroed */
 #define _delete(P) free((void *)(P))
 
+#ifndef S_ISDIR
+#define S_ISDIR(mode)  (((mode) & S_IFMT) == S_IFDIR)
+#endif
+
 /* ------------------------------------------------------------------------- */
 
 #ifndef LIBCONFIG_STATIC


### PR DESCRIPTION
Define S_ISDIR macro missing in MSVC (VS 2013)