### PR TITLE
Percent sign starts comment until line end

### DIFF
--- a/lib/scanner.l
+++ b/lib/scanner.l
@@ -94,7 +94,7 @@ hex               0[Xx][0-9A-Fa-f]+
 hex64             0[Xx][0-9A-Fa-f]+L(L)?
 hexchar           \\[Xx][0-9A-Fa-f]{2}
 float             ([-+]?([0-9]*)?\.[0-9]*([eE][-+]?[0-9]+)?)|([-+]?([0-9]+)(\.[0-9]*)?[eE][-+]?[0-9]+)
-comment           (#|\/\/).*$
+comment           (#|%|\/\/).*$
 include_open      ^[ \t]*@include[ \t]+\"
 
 %x COMMENT STRING INCLUDE


### PR DESCRIPTION
The percent sign '%' will now make the remainder of a line
a comment just like the hash sign '#' already does.
This is in accordance to some languages such as TeX that
already use '%' as a comment initiator.