### PR TITLE
Octal ints

### DIFF
--- a/doc/libconfig.texi
+++ b/doc/libconfig.texi
@@ -399,7 +399,8 @@ application:
     pi = 3.141592654;
     bigint = 9223372036854775807L;
     columns = [ "Last Name", "First Name", "MI" ];
-    bitmask = 0x1FC3;
+    bitmask = 0x1FC3;	// hex
+    umask = 0027;	// octal. Range limited to that of "int"
   @};
 @};
 @end smallexample
@@ -505,7 +506,8 @@ more decimal digits (@samp{0} - @samp{9}), with an optional leading
 sign character (@samp{+} or @samp{-}); or as a hexadecimal value
 consisting of the characters @samp{0x} followed by a series of one or
 more hexadecimal digits (@samp{0} - @samp{9}, @samp{A} - @samp{F},
-@samp{a} - @samp{f}).
+@samp{a} - @samp{f}). Additionally, octal notation integers (that is,
+those having a leading zero with non-zero value) are also allowed.
 
 @node 64-bit Integer Values, Floating Point Values, Integer Values, Configuration Files
 @comment  node-name,  next,  previous,  up

--- a/lib/scanner.l
+++ b/lib/scanner.l
@@ -244,7 +244,7 @@ include_dir_open  ^[ \t]*@include_dir[ \t]+\"
                     }
                     errno = errsave;
                     if( '0'==*yytext && '\0'!=*(yytext+1) )
-                    {	// it's octal... so INT we go
+                    {	/* it's octal... so INT we go */
                       yylval->ival=(int)(llval);
                       return(TOK_INTEGER);
                     }

--- a/lib/scanner.l
+++ b/lib/scanner.l
@@ -39,6 +39,7 @@
 #endif
 
 #include <stdlib.h>
+#include <errno.h>
 #include <ctype.h>
 #include <string.h>
 #include <limits.h>
@@ -232,7 +233,22 @@ include_dir_open  ^[ \t]*@include_dir[ \t]+\"
 {float}           { yylval->fval = atof(yytext); return(TOK_FLOAT); }
 {integer}         {
                     long long llval;
-                    llval = atoll(yytext);
+                    char *endptr;
+                    int errsave = errno;
+                    errno = 0;
+                    llval = strtoll(yytext, &endptr, 0);	/* base 10 or base 8 */
+                    if( '\0'!=*endptr || 0!=errno )
+                    {
+                      errno = 0;
+                      return(TOK_ERROR);	/* some error occured ... */
+                    }
+                    errno = errsave;
+                    if( '0'==*yytext && '\0'!=*(yytext+1) )
+                    {	// it's octal... so INT we go
+                      yylval->ival=(int)(llval);
+                      return(TOK_INTEGER);
+                    }
+
                     if((llval < INT_MIN) || (llval > INT_MAX))
                     {
                       yylval->llval = llval;

--- a/lib/scanner.l
+++ b/lib/scanner.l
@@ -237,15 +237,15 @@ include_dir_open  ^[ \t]*@include_dir[ \t]+\"
                     int errsave = errno;
                     errno = 0;
                     llval = strtoll(yytext, &endptr, 0);	/* base 10 or base 8 */
-                    if( '\0'!=*endptr || 0!=errno )
+                    if(*endptr || errno)
                     {
                       errno = 0;
                       return(TOK_ERROR);	/* some error occured ... */
                     }
                     errno = errsave;
-                    if( '0'==*yytext && '\0'!=*(yytext+1) )
-                    {	/* it's octal... so INT we go */
-                      yylval->ival=(int)(llval);
+                    if((*yytext == '0') && (*(yytext+1) != '\0'))
+                    {   /* it's octal... so INT we go */
+                      yylval->ival = (int)(llval);
                       return(TOK_INTEGER);
                     }
 

--- a/lib/wincompat.h
+++ b/lib/wincompat.h
@@ -40,6 +40,7 @@
 #if !defined(__MINGW32__) && _MSC_VER < 1800
 #define atoll     _atoi64
 #define strtoull  _strtoui64
+#define strtoll   _strtoi64
 #endif
 
 #if !defined(S_ISDIR) && defined(S_IFMT) && defined(S_IFDIR)


### PR DESCRIPTION
Support for converting values expressed in octal. Range limited to INT_MIN..0..INT_MAX. 
Who would want to write a long long in octal?

Intended to be used for umasks, UN*X file permissions and the like.

The only potential incompatibility is that it sets -std=c99 (for full support of strtoull)... but all supported compilers should support that anyway. Would benefit from a subsequent patch that'll remove the newly emited warnings (not in this code), though