### PR TITLE
Implement float_precision parameter (Closes #31)

### DIFF
--- a/doc/libconfig.texi
+++ b/doc/libconfig.texi
@@ -824,6 +824,22 @@ configuration @var{config}, or @code{NULL} if none is set.
 
 @end deftypefun
 
+@deftypefun void config_set_float_precision(@w{config_t *@var{config}}, @w{unsigned short @var{digits}})
+@deftypefunx {unsigned short} config_get_float_precision(@w{config_t *@var{config}})
+
+@b{Since @i{v1.6}}
+
+These functions set and get the number of decimal digits to output when writing
+the configuration to a file or stream.
+
+@code{config_set_float_precision(config,digits)} specifies "the number of
+digits to appear after the radix character". Please refer to printf(3) for details.
+
+Valid float precision range from 0 (no decimals) to about 15 (implementation defined).
+This parameter has no effect on parsing.
+
+@end deftypefun
+
 @deftypefun void config_set_options (@w{config_t *@var{config}}, @w{int @var{options}})
 @deftypefunx int config_get_options (@w{config_t *@var{config}})
 
@@ -1462,6 +1478,19 @@ spaces, or by a single tab character if @var{width} is 0. The tab
 width has no effect on parsing.
 
 Valid tab widths range from 0 to 15. The default tab width is 2.
+
+@end deftypemethod
+
+@deftypemethod Config void setFloatPrecision (@w{unsigned short @var{width}})
+@deftypemethodx Config {unsigned short} getFloatPrecision ()
+
+These methods set and get the float precision for the configuration. 
+This parameter influences the formatting of floating point settings in
+the configuration when it is written to a file or stream.
+Float precision has no effect on parsing.
+
+Valid precisions range from 0 to about 15 (implementation dependent),
+though the library will accept and store values up to 255.
 
 @end deftypemethod
 

--- a/lib/libconfig.h
+++ b/lib/libconfig.h
@@ -142,6 +142,10 @@ extern LIBCONFIG_API void config_set_destructor(config_t *config,
 extern LIBCONFIG_API void config_set_include_dir(config_t *config,
                                                  const char *include_dir);
 
+extern LIBCONFIG_API void config_set_float_precision(config_t *config,
+                                                          unsigned short digits);
+extern LIBCONFIG_API unsigned short config_get_float_precision(config_t *config);
+
 extern LIBCONFIG_API void config_init(config_t *config);
 extern LIBCONFIG_API void config_destroy(config_t *config);
 
@@ -299,7 +303,7 @@ extern LIBCONFIG_API int config_lookup_string(const config_t *config,
   (C)->tab_width = ((W) & 0x0F)
 
 #define /* unsigned char */ config_get_tab_width(/* const config_t * */ C) \
-  ((C)->tab_width)
+  ((C)->tab_width & 0x0F)
 
 #define /* unsigned short */ config_setting_source_line(   \
   /* const config_setting_t * */ S)                        \

--- a/lib/libconfig.h++
+++ b/lib/libconfig.h++
@@ -466,6 +466,9 @@ class LIBCONFIGXX_API Config
   void setTabWidth(unsigned short width);
   unsigned short getTabWidth() const;
 
+  void setFloatPrecision(unsigned short digits);
+  unsigned short getFloatPrecision() const;
+
   void setIncludeDir(const char *includeDir);
   const char *getIncludeDir() const;
 

--- a/lib/libconfigcpp.c++
+++ b/lib/libconfigcpp.c++
@@ -374,6 +374,20 @@ unsigned short Config::getTabWidth() const
 
 // ---------------------------------------------------------------------------
 
+void Config::setFloatPrecision(unsigned short digits)
+{
+  return (config_set_float_precision(_config,digits));
+}
+
+// ---------------------------------------------------------------------------
+
+unsigned short Config::getFloatPrecision() const
+{
+  return (config_get_float_precision(_config));
+}
+
+// ---------------------------------------------------------------------------
+
 void Config::setIncludeDir(const char *includeDir)
 {
   config_set_include_dir(_config, includeDir);


### PR DESCRIPTION
Added the ability to specify the amount of decimal digits (precision)
to be used when writing out (file or stream) a configuration.
Includes C & C++ versions.

As per zhaopingsun's suggestion