### PR TITLE
Robustness & bug fixes for tab_width handling

### DIFF
--- a/lib/libconfig.c
+++ b/lib/libconfig.c
@@ -47,10 +47,11 @@
 
 #define PATH_TOKENS ":./"
 #define CHUNK_SIZE 16
-#define FLOAT_PRECISION DBL_DIG
+#define FLOAT_PRECISION 2
 
 #define TAB2DIGITS(x)  (((x) & 0xFF00) >> 8)
 #define DIGITS2TAB(x)  (((x) & 0xFF) << 8)
+#define TAB2TAB(x)     ((x) & 0xF)
 
 #define _new(T) (T *)calloc(1, sizeof(T)) /* zeroed */
 #define _delete(P) free((void *)(P))
@@ -371,7 +372,7 @@ static void __config_write_value(const config_t *config,
           fputc('\n', stream);
 
           if(depth > 1)
-            __config_indent(stream, depth, config->tab_width);
+            __config_indent(stream, depth, TAB2TAB(config->tab_width));
         }
 
         fprintf(stream, "{\n");
@@ -387,7 +388,7 @@ static void __config_write_value(const config_t *config,
       }
 
       if(depth > 1)
-        __config_indent(stream, depth, config->tab_width);
+        __config_indent(stream, depth, TAB2TAB(config->tab_width));
 
       if(depth > 0)
         fputc('}', stream);
@@ -650,7 +651,7 @@ static void __config_write_setting(const config_t *config,
     config, CONFIG_OPTION_COLON_ASSIGNMENT_FOR_NON_GROUPS) ? ':' : '=';
 
   if(depth > 1)
-    __config_indent(stream, depth, config->tab_width);
+    __config_indent(stream, depth, TAB2TAB(config->tab_width));
 
 
   if(setting->name)
@@ -758,13 +759,30 @@ void config_destroy(config_t *config)
 }
 
 /* ------------------------------------------------------------------------- */
+
+void config_set_tab_width(config_t *config,
+                          unsigned short width)
+{
+  /* As per documentation: valid range= 0..15 */
+  config->tab_width = (width <= 15) ? width : 15;
+}
+
+/* ------------------------------------------------------------------------- */
+
+unsigned short config_get_tab_width(const config_t *config)
+{
+  return TAB2TAB(config->tab_width);
+}
+
+/* ------------------------------------------------------------------------- */
+
 void config_set_float_precision(config_t *config,
                                           unsigned short digits)
 {
   config->tab_width |= DIGITS2TAB(digits);
 }
 
-unsigned short config_get_float_precision(config_t *config)
+unsigned short config_get_float_precision(const config_t *config)
 {
   return TAB2DIGITS(config->tab_width);
 }
@@ -786,8 +804,8 @@ void config_init(config_t *config)
    * (ab)using the existing macros' 0x0F mask in order to preserve
    * API & ABI compatibility ; changes are fully backwards compatible
    */
-  config->tab_width = 2;
-  config->tab_width |= DIGITS2TAB(FLOAT_PRECISION);    /* float_digits */
+  config->tab_width = FLOAT_PRECISION;
+  config->tab_width |= DIGITS2TAB(2);    /* float_digits */
 }
 
 /* ------------------------------------------------------------------------- */

--- a/lib/libconfig.h
+++ b/lib/libconfig.h
@@ -144,7 +144,11 @@ extern LIBCONFIG_API void config_set_include_dir(config_t *config,
 
 extern LIBCONFIG_API void config_set_float_precision(config_t *config,
                                                           unsigned short digits);
-extern LIBCONFIG_API unsigned short config_get_float_precision(config_t *config);
+extern LIBCONFIG_API unsigned short config_get_float_precision(const config_t *config);
+
+extern LIBCONFIG_API void config_set_tab_width(config_t *config,
+                                               unsigned short width);
+extern LIBCONFIG_API unsigned short config_get_tab_width(const config_t *config);
 
 extern LIBCONFIG_API void config_init(config_t *config);
 extern LIBCONFIG_API void config_destroy(config_t *config);
@@ -297,13 +301,6 @@ extern LIBCONFIG_API int config_lookup_string(const config_t *config,
 
 #define /* short */ config_get_default_format(/* config_t * */ C)       \
   ((C)->default_format)
-
-#define /* void */ config_set_tab_width(/* config_t * */ C,     \
-                                        /* unsigned short */ W) \
-  (C)->tab_width = ((W) & 0x0F)
-
-#define /* unsigned char */ config_get_tab_width(/* const config_t * */ C) \
-  ((C)->tab_width & 0x0F)
 
 #define /* unsigned short */ config_setting_source_line(   \
   /* const config_setting_t * */ S)                        \


### PR DESCRIPTION
 * Reset default float_precision to 2 (from leftover DBL_DIG)

 * bugfix (missing mask) that multiplied indentation by 3840 (0x0F00)

 * Robustness: convert get|set_tab_width() from macro to function
   Also: const correctness