### PR TITLE
Add fsync call after after writing

### DIFF
--- a/lib/libconfig.c
+++ b/lib/libconfig.c
@@ -726,6 +726,7 @@ int config_read_file(config_t *config, const char *filename)
 
 int config_write_file(config_t *config, const char *filename)
 {
+  int fd;
   FILE *stream = fopen(filename, "wt");
   if(stream == NULL)
   {
@@ -735,6 +736,24 @@ int config_write_file(config_t *config, const char *filename)
   }
 
   config_write(config, stream);
+
+  fd = fileno(stream);
+  if(fd < 0)
+  {
+    config->error_text = __io_error;
+    config->error_type = CONFIG_ERR_FILE_IO;
+    fclose(stream);
+    return(CONFIG_FALSE);
+  }
+
+  if(fsync(fd) < 0)
+  {
+      config->error_text = __io_error;
+      config->error_type = CONFIG_ERR_FILE_IO;
+      fclose(stream);
+      return(CONFIG_FALSE);
+  }
+
   fclose(stream);
   config->error_type = CONFIG_ERR_NONE;
   return(CONFIG_TRUE);


### PR DESCRIPTION
This makes sure that all data will be written on the underlying hardware.

In my application, I reopen and close the file again to make sure that data are present on the NAND flash, it would faster and to do it in one call.

I use fsync and not fflush because I'm working on UBIFS and the UBIFS documentations says:

> The fflush() function flushes the libc-level buffers, while sync(), fsync(), etc flush kernel-level buffers.

I understand that this feature would not be useful for everyone, maybe for those who need it, we could had a new function. That's why I understand if you reject my patch or have better suggestion on how to handle that!
