### PR TITLE
libconfig: check against uint max to avoid wrap arounds

### DIFF
--- a/lib/scanner.l
+++ b/lib/scanner.l
@@ -251,6 +251,11 @@ include_dir_open  ^[ \t]*@include_dir[ \t]+\"
 
                     if((llval < INT_MIN) || (llval > INT_MAX))
                     {
+                      if((llval > UINT_MAX))
+			{
+			errno = -ERANGE;
+			return (TOK_ERROR);
+			}
                       yylval->llval = llval;
                       return(TOK_INTEGER64);
                     }


### PR DESCRIPTION
Avoid enabling user input which wraps around UINT_MAX.

Signed-off-by: Luis R. Rodriguez <mcgrof@kernel.org>