### PR TITLE
Update ruby bindings for libconfig

### DIFF
--- a/contrib/libconfig-ruby/Rakefile
+++ b/contrib/libconfig-ruby/Rakefile
@@ -3,7 +3,7 @@ require 'rubygems/package_task'
 
 spec = Gem::Specification.new do |s| 
   s.name = "rconfig"
-  s.version = "1.0"
+  s.version = "1.0.1"
   s.author = "Peter Zotov"
   s.email = "whitequark@whitequark.ru"
   s.platform = Gem::Platform::RUBY
@@ -12,6 +12,6 @@ spec = Gem::Specification.new do |s|
   s.extensions = 'ext/extconf.rb'
 end
  
-Rake::GemPackageTask.new(spec) do |pkg| 
+Gem::PackageTask.new(spec) do |pkg|
 end
  

--- a/contrib/libconfig-ruby/ext/rconfig.c
+++ b/contrib/libconfig-ruby/ext/rconfig.c
@@ -104,9 +104,9 @@ static void rconfig_update_setting(config_setting_t* setting, VALUE value)
     case CONFIG_TYPE_FLOAT:
 // ruby1.9 check
 #if HAVE_RB_BLOCK_CALL
-      config_setting_set_float(setting, RFLOAT(value)->float_value);
+      config_setting_set_float(setting, RFLOAT_VALUE(value));
 #else
-      config_setting_set_float(setting, RFLOAT(value)->value);
+      config_setting_set_float(setting, RFLOAT_VALUE(value));
 #endif
       break;
     


### PR DESCRIPTION
`Rake::GemPackageTask` has been deprecated in favour of `Gem::PackageTask`.

As of Ruby 2.2 `RFLOAT` is private, use `RFLOAT_VALUE` to obtain the value.