### PR TITLE
fixed from PVS-Studio

### DIFF
--- a/tests/tests.c
+++ b/tests/tests.c
@@ -119,6 +119,7 @@ static const char *read_file_to_string(const char *file)
 
   size = stbuf.st_size;
   buf = (char *)malloc(size + 1);
+  TT_ASSERT_PTR_NOTNULL(buf);
 
   fp = fopen(file, "rt");
   TT_ASSERT_PTR_NOTNULL(fp);


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio. Warnings:

[V575](https://www.viva64.com/en/w/v575/) The potential null pointer is passed into 'fread' function. Inspect the first argument. tests.c 126