### PR TITLE
Add inline functions for readFile and writeFile for std::string

### DIFF
--- a/doc/libconfig.texi
+++ b/doc/libconfig.texi
@@ -1451,12 +1451,17 @@ The @code{write()} method writes the configuration to the given @var{stream}.
 @end deftypemethod
 
 @deftypemethod Config void readFile (@w{const char * @var{filename}})
-@deftypemethodx Config void writeFile (@w{const char * @var{filename}}) const
+@deftypemethodx Config void readFile (@w{const std::string &@var{filename}})
 
 The @code{readFile()} method reads and parses a configuration from the
 file named @var{filename}. A @code{ParseException} is thrown if a
 parse error occurs. A @code{FileIOException} is thrown if the file
 cannot be read.
+
+@end deftypemethod
+
+@deftypemethod Config void writeFile (@w{const char * @var{filename}})
+@deftypemethodx Config void writeFile (@w{const std::string &@var{filename}})
 
 The @code{writeFile()} method writes the configuration to the file
 named @var{filename}. A @code{FileIOException} is thrown if the file cannot

--- a/lib/libconfig.h++
+++ b/lib/libconfig.h++
@@ -492,7 +492,12 @@ class LIBCONFIGXX_API Config
   { return(readString(str.c_str())); }
 
   void readFile(const char *filename);
+  inline void readFile(const std::string &filename)
+  { readFile(filename.c_str()); }
+
   void writeFile(const char *filename);
+  inline void writeFile(const std::string &filename)
+  { writeFile(filename.c_str()); }
 
   Setting & lookup(const char *path) const;
   inline Setting & lookup(const std::string &path) const


### PR DESCRIPTION
Add inline functions for `readFile` and `writeFile` (in similar fashion to the other inline functions) so that `readFile` and `writeFile` can take a `std::string`.