### PR TITLE
Make including library easier

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,11 +1,14 @@
 cmake_minimum_required(VERSION 3.1)
 
-project(libconfig)
+project(libconfig LANGUAGES C CXX)
 option(BUILD_EXAMPLES "Enable examples" ON)
 option(BUILD_SHARED_LIBS  "Enable shared library" ON)
 option(BUILD_TESTS "Enable tests" ON)
 
 set_property(GLOBAL	PROPERTY USE_FOLDERS ON)
+
+set(CMAKE_C_STANDARD 99)
+set(CMAKE_C_EXTENSIONS ON)
 
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/out)
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/out)
@@ -14,7 +17,7 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/out)
 if(BUILD_SHARED_LIBS)
 	add_definitions(-DLIBCONFIG_EXPORTS)
 	add_definitions(-DLIBCONFIGXX_EXPORTS)
-else()	
+else()
 	add_definitions(-DLIBCONFIG_STATIC)
 	add_definitions(-DLIBCONFIGXX_STATIC)
 endif()

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -18,8 +18,8 @@ set(libsrc
     strbuf.c
     strvec.c
     util.c
-	wincompat.c)
-	
+    wincompat.c)
+
 set(libinc_cpp
     libconfig.h++
     libconfig.hh)
@@ -31,7 +31,7 @@ set(libsrc_cpp
 add_library(libconfig ${libsrc} ${libinc})
 add_library(libconfig++ ${libsrc_cpp} ${libinc_cpp})
 
-set_target_properties(libconfig 
+set_target_properties(libconfig
     PROPERTIES LINKER_LANGUAGE C
         PUBLIC_HEADER "${libinc}")
 set_target_properties(libconfig++
@@ -44,7 +44,7 @@ target_compile_definitions(libconfig
         YY_NO_UNISTD_H
         YY_USE_CONST )
 
-target_compile_definitions(libconfig++ 
+target_compile_definitions(libconfig++
     PRIVATE
         _CRT_SECURE_NO_DEPRECATE
         YY_NO_UNISTD_H

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,12 +1,14 @@
 add_executable(libconfig_tests
-	tests.c )
-	
+    tests.c
+)
+
 target_link_libraries(libconfig_tests
-	libconfig
-	libtinytest )
+    libconfig
+    libtinytest
+)
 
-target_include_directories(libconfig_tests
-	PRIVATE ${CMAKE_SOURCE_DIR}/lib
-		${CMAKE_SOURCE_DIR}/tinytest )
-
-add_test(NAME libconfig_tests COMMAND libconfig_tests)
+add_test(
+    NAME libconfig_tests
+    COMMAND libconfig_tests
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/tests
+)

--- a/tinytest/CMakeLists.txt
+++ b/tinytest/CMakeLists.txt
@@ -1,12 +1,17 @@
 add_library(libtinytest STATIC
-	tinytest.h
-	tinytest.c)
+    tinytest.c tinytest.h)
+
+target_include_directories(libtinytest
+    PUBLIC
+        $<INSTALL_INTERFACE:.>
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+)
 
 if(CMAKE_HOST_WIN32)
-	if(MSVC)	
-		set_target_properties(libtinytest
-			PROPERTIES
-				COMPILE_FLAGS "/wd4996"
-			)
-	endif()
+    if(MSVC)
+        set_target_properties(libtinytest
+            PROPERTIES
+                COMPILE_FLAGS "/wd4996"
+            )
+    endif()
 endif()


### PR DESCRIPTION
libconfig did not previously target a C standard, instead assuming that the parent was using a compatible one.