### PR TITLE
Fix portability problem due to == test

### DIFF
--- a/contrib/ls-config/debian/postinst
+++ b/contrib/ls-config/debian/postinst
@@ -32,7 +32,7 @@ config_path() {
 	CHK="$(echo "$L" | sed -E 's/^([\ \t]+)//g')"
 	CHK="${CHK:0:5}"
 	NF="$NF$IFS$L"
-	if [ "$CHK" == "PATH=" ]; then
+	if [ "$CHK" = "PATH=" ]; then
 	    NF="$NF$IFS#Configuration path for ls scripting"
 	    NF="$NF$IFS"
 	    NF="${NF}PATH=\"\$PATH:/usr/share/ls/lib\"$IFS"


### PR DESCRIPTION
The "test" command, as well as the "[" command, are not required to know
the "==" operator. Only a few implementations like bash and some
versions of ksh support it.

When you run "test foo == foo" on a platform that does not support the
"==" operator, the result will be "false" instead of "true". This can
lead to unexpected behavior.