### PR TITLE
Add missing include in CMakeLists

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,7 @@ else()
 endif()
 
 include(GNUInstallDirs)
+include(CheckSymbolExists)
 add_subdirectory(lib)
 
 if(BUILD_EXAMPLES)


### PR DESCRIPTION
Add the `include(CheckSymbolExists)` to allow the usage of the `check_symbol_exists()` macro and fix #136