### PR TITLE
Add modern *Config.cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,12 @@
 cmake_minimum_required(VERSION 3.1)
 
-project(libconfig LANGUAGES C CXX)
+# Extract version from configure.ac.
+set(VERSION_REGEX "^AC_INIT\\(libconfig,[ \t]+([0-9\.]+),.*")
+file(STRINGS "configure.ac"
+  VERSION_STRING REGEX ${VERSION_REGEX})
+string(REGEX REPLACE ${VERSION_REGEX} "\\1" VERSION_STRING "${VERSION_STRING}")
+
+project(libconfig LANGUAGES C CXX VERSION ${VERSION_STRING})
 option(BUILD_EXAMPLES "Enable examples" ON)
 option(BUILD_SHARED_LIBS  "Enable shared library" ON)
 option(BUILD_TESTS "Enable tests" ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,7 @@ else()
 endif()
 
 include(GNUInstallDirs)
+include(CheckSymbolExists)
 add_subdirectory(lib)
 
 if(BUILD_EXAMPLES)

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -80,7 +80,16 @@ if(CMAKE_HOST_WIN32)
     target_link_libraries(${libname}++ Shlwapi.lib)
 endif()
 
+target_include_directories(${libname}
+  PUBLIC "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>"
+  )
+
+target_include_directories(${libname}++
+  PUBLIC "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>"
+  )
+
 install(TARGETS ${libname}
+    EXPORT libconfigTargets
     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
@@ -88,8 +97,29 @@ install(TARGETS ${libname}
 )
 
 install(TARGETS ${libname}++
+    EXPORT libconfig++Targets
     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
     PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
 )
+
+
+include(CMakePackageConfigHelpers)
+foreach(target_name libconfig libconfig++)
+  write_basic_package_version_file("${target_name}ConfigVersion.cmake"
+    VERSION ${PACKAGE_VERSION}
+    COMPATIBILITY SameMajorVersion
+    )
+
+  install(EXPORT ${target_name}Targets
+    FILE "${target_name}Config.cmake"
+    NAMESPACE libconfig::
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/libconfig
+    )
+
+  install(FILES
+    "${CMAKE_CURRENT_BINARY_DIR}/${target_name}ConfigVersion.cmake"
+    DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/libconfig"
+    )
+endforeach()


### PR DESCRIPTION
The current CMake recipes only install libraries and headers and the existing
`*Config.cmake` files are very minimal and inflexible. So I wrote a generator
for `*Config.cmake` files. This allows you to use libconfig in CMake projects
like so:

``` cmake
find_package(libconfig CONFIG REQUIRED)
target_link_libraries(example_c PUBLIC libconfig::config)

find_package(libconfig++ CONFIG REQUIRED)
target_link_libraries(example_cpp PUBLIC libconfig::config++)
```

It works with Linux and OSX. I can't test it with Windows.

Includes <https://github.com/hyperrealm/libconfig/pull/138> because CMake fails
without it.

Fixes #143