### PR TITLE
Fix compilation of tests for out-of-tree-build

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -4,6 +4,8 @@ else()
     set(libname "config")
 endif()
 
+include_directories(${CMAKE_SOURCE_DIR}/lib)
+
 add_executable(libconfig_tests
     tests.c
 )


### PR DESCRIPTION
We have to modify the include path, otherwise I get

| libconfig/tests/tests.c:31:10: fatal error: libconfig.h: No such file or directory
|    31 | #include <libconfig.h>
|       |          ^~~~~~~~~~~~~
| compilation terminated.

Signed-off-by: Bernhard Walle <bernhard.walle@ncp-e.com>