### PR TITLE
Add option to override duplicate settings

### DIFF
--- a/doc/libconfig.texi
+++ b/doc/libconfig.texi
@@ -950,6 +950,13 @@ when writing floating point values (corresponding to @code{printf()}
 This option controls whether the @code{config_write_file()} function performs
 an @i{fsync} operation after writing the configuration and before closing the
 file. By default this option is turned off.
+
+@item CONFIG_OPTION_ALLOW_OVERRIDES
+(@b{Since @i{v1.7.3}})
+This option controls whether duplicate settings override previous settings
+with the same name. If this option is turned off, duplicate settings are
+rejected. By default this option is turned off.
+
 @end table
 
 @end deftypefun
@@ -1595,6 +1602,12 @@ when writing floating point values (corresponding to @code{printf()}
 This option controls whether the @code{writeFile()} method performs an @i{fsync}
 operation after writing the configuration and before closing the file. By
 default this option is turned off.
+
+@item Config::OptionAllowOverrides
+(@b{Since @i{v1.7.3}})
+This option controls whether duplicate settings override previous settings
+with the same name. If this option is turned off, duplicate settings are
+rejected. By default this option is turned off.
 
 @end table
 

--- a/lib/libconfig.c
+++ b/lib/libconfig.c
@@ -1626,7 +1626,12 @@ config_setting_t *config_setting_add(config_setting_t *parent,
   }
 
   if(config_setting_get_member(parent, name) != NULL)
-    return(NULL); /* already exists */
+  {
+    if(config_get_option(parent->config, CONFIG_OPTION_ALLOW_OVERRIDES))
+      config_setting_remove(parent, name);
+    else
+      return(NULL); /* already exists */
+  }
 
   return(config_setting_create(parent, name, type));
 }

--- a/lib/libconfig.h
+++ b/lib/libconfig.h
@@ -65,6 +65,7 @@ extern "C" {
 #define CONFIG_OPTION_OPEN_BRACE_ON_SEPARATE_LINE     0x10
 #define CONFIG_OPTION_ALLOW_SCIENTIFIC_NOTATION       0x20
 #define CONFIG_OPTION_FSYNC                           0x40
+#define CONFIG_OPTION_ALLOW_OVERRIDES                 0x80
 
 #define CONFIG_TRUE  (1)
 #define CONFIG_FALSE (0)

--- a/lib/libconfig.h++
+++ b/lib/libconfig.h++
@@ -449,7 +449,8 @@ class LIBCONFIGXX_API Config
     OptionColonAssignmentForNonGroups = 0x08,
     OptionOpenBraceOnSeparateLine = 0x10,
     OptionAllowScientificNotation = 0x20,
-    OptionFsync = 0x40
+    OptionFsync = 0x40,
+    OptionAllowOverrides = 0x80
   };
 
   Config();

--- a/tests/testdata/override_setting.cfg
+++ b/tests/testdata/override_setting.cfg
@@ -1,0 +1,20 @@
+group:
+{
+  @include "more.cfg"
+  message = "overridden";
+  array = (1,2);
+  array = (3);
+  inner = {
+    name = "value";
+    none = "none";
+  };
+  inner = {
+    name = "other-value";
+    name = "overridden";
+    other = "other";
+  };
+};
+int = 1;
+int = 2;
+string = "value";
+string = "overridden";

--- a/tests/tests.c
+++ b/tests/tests.c
@@ -487,6 +487,64 @@ TT_TEST(EscapedStrings)
 
 /* ------------------------------------------------------------------------- */
 
+TT_TEST(OverrideSetting)
+{
+  config_t cfg;
+  int ok;
+  int ival;
+  const char *str;
+
+  config_init(&cfg);
+  config_set_options(&cfg, CONFIG_OPTION_ALLOW_OVERRIDES);
+  config_set_include_dir(&cfg, "./testdata");
+
+  ok = config_read_file(&cfg, "testdata/override_setting.cfg");
+  if(!ok)
+  {
+    printf("error: %s:%d\n", config_error_text(&cfg),
+           config_error_line(&cfg));
+  }
+  TT_ASSERT_TRUE(ok);
+
+  ok = config_lookup_string(&cfg, "group.message", &str);
+  TT_ASSERT_TRUE(ok);
+  TT_ASSERT_STR_EQ("overridden", str);
+
+  ok = config_lookup_string(&cfg, "group.inner.name", &str);
+  TT_ASSERT_TRUE(ok);
+  TT_ASSERT_STR_EQ("overridden", str);
+
+  ok = config_lookup_string(&cfg, "group.inner.other", &str);
+  TT_ASSERT_TRUE(ok);
+  TT_ASSERT_STR_EQ("other", str);
+
+  ok = config_lookup_string(&cfg, "group.inner.none", &str);
+  TT_ASSERT_FALSE(ok);
+
+  ok = config_lookup_string(&cfg, "group.inner.other", &str);
+  TT_ASSERT_TRUE(ok);
+  TT_ASSERT_STR_EQ("other", str);
+
+  ok = config_lookup_string(&cfg, "string", &str);
+  TT_ASSERT_TRUE(ok);
+  TT_ASSERT_STR_EQ("overridden", str);
+
+  ok = config_lookup_int(&cfg, "int", &ival);
+  TT_ASSERT_TRUE(ok);
+  TT_ASSERT_INT_EQ(ival, 2);
+
+  ok = config_lookup_int(&cfg, "group.array.[0]", &ival);
+  TT_ASSERT_TRUE(ok);
+  TT_ASSERT_INT_EQ(ival, 3);
+
+  ok = config_lookup_int(&cfg, "group.array.[1]", &ival);
+  TT_ASSERT_FALSE(ok);
+
+  config_destroy(&cfg);
+}
+
+/* ------------------------------------------------------------------------- */
+
 int main(int argc, char **argv)
 {
   int failures;
@@ -504,6 +562,7 @@ int main(int argc, char **argv)
   TT_SUITE_TEST(LibConfigTests, BigInt7);
   TT_SUITE_TEST(LibConfigTests, RemoveSetting);
   TT_SUITE_TEST(LibConfigTests, EscapedStrings);
+  TT_SUITE_TEST(LibConfigTests, OverrideSetting);
   TT_SUITE_RUN(LibConfigTests);
   failures = TT_SUITE_NUM_FAILURES(LibConfigTests);
   TT_SUITE_END(LibConfigTests);


### PR DESCRIPTION
This pull request adds a new option as suggested in #83: `CONFIG_OPTION_ALLOW_OVERRIDES`.

libconfig rejects settings with duplicate names by default. With this option enabled, libconfig will instead remove the old setting and add the new one.

```
host = "example.com";
# remove setting "host" and add new setting "host":
host = "github.com";
```

My primary use case is using `@include` to setup defaults and then overriding specific settings.
For example:

```
unit = {
  # defaults.conf sets "delay" and other settings
  @include "defaults.conf"
  delay = 2000;
};
```

If there is anything that I can do to get this merged, please let me know.