### PR TITLE
Fixed project version escape character

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.1)
 
 # Extract version from configure.ac.
-set(VERSION_REGEX "^AC_INIT\\(libconfig,[ \t]+([0-9\\.]+),.*")
+set(VERSION_REGEX "^AC_INIT\\(libconfig,[ \t]+([0-9.]+),.*")
 file(STRINGS "configure.ac"
   VERSION_STRING REGEX ${VERSION_REGEX})
 string(REGEX REPLACE ${VERSION_REGEX} "\\1" VERSION_STRING "${VERSION_STRING}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.1)
 
 # Extract version from configure.ac.
-set(VERSION_REGEX "^AC_INIT\\(libconfig,[ \t]+([0-9\.]+),.*")
+set(VERSION_REGEX "^AC_INIT\\(libconfig,[ \t]+([0-9\\.]+),.*")
 file(STRINGS "configure.ac"
   VERSION_STRING REGEX ${VERSION_REGEX})
 string(REGEX REPLACE ${VERSION_REGEX} "\\1" VERSION_STRING "${VERSION_STRING}")


### PR DESCRIPTION
```
\\ -> \
\t -> Tab Key
\. -> INVALID
```
`\.` does not escape `.` on Regex Level but on string level. To escape `.` on Regex level, you need to send `\.` to Regex which is `\\.` on string level (can be very confusing when you need to escape `\` on Regex level resulting in `\\\\` on string level).

Did not notice this myself but CLion showed me this as an error.