### PR TITLE
Add isString () convenience method

### DIFF
--- a/doc/libconfig.texi
+++ b/doc/libconfig.texi
@@ -2167,11 +2167,12 @@ These convenience methods test if a setting is of a given type.
 @deftypemethod Setting bool isAggregate () const
 @deftypemethodx Setting bool isScalar () const
 @deftypemethodx Setting bool isNumber () const
+@deftypemethodx Setting bool isString () const
 
 These convenience methods test if a setting is of an aggregate type (a
 group, array, or list), of a scalar type (integer, 64-bit integer,
-floating point, boolean, or string), and of a number (integer, 64-bit
-integer, or floating point), respectively.
+floating point, boolean, or string), of a number (integer, 64-bit
+integer, or floating point), and of a string respectively.
 
 @end deftypemethod
 

--- a/lib/libconfig.h++
+++ b/lib/libconfig.h++
@@ -309,6 +309,9 @@ class LIBCONFIGXX_API Setting
   {
     return((_type == TypeInt) || (_type == TypeInt64) || (_type == TypeFloat));
   }
+  
+  inline bool isString() const
+  { return(_type == TypeString); }
 
   unsigned int getSourceLine() const;
   const char *getSourceFile() const;


### PR DESCRIPTION
Adds a convenience method for checking if a libconfig::Setting is a string, also adds it to doc/libconfig.texi.