### PR TITLE
Optionally write comments to config files

### DIFF
--- a/examples/c++/example3.cpp
+++ b/examples/c++/example3.cpp
@@ -39,7 +39,8 @@ int main(int argc, char **argv)
   Setting &root = cfg.getRoot();
 
   // Add some settings to the configuration.
-  Setting &address = root.add("address", Setting::TypeGroup);
+  Setting &address = root.add("address", Setting::TypeGroup,
+                                "Address for parcel delivery");
 
   address.add("street", Setting::TypeString) = "1 Woz Way";
   address.add("city", Setting::TypeString) = "San Jose";

--- a/examples/c/example3.c
+++ b/examples/c/example3.c
@@ -39,7 +39,8 @@ int main(int argc, char **argv)
   root = config_root_setting(&cfg);
 
   /* Add some settings to the configuration. */
-  group = config_setting_add(root, "address", CONFIG_TYPE_GROUP);
+  group = config_setting_add_with_comment(
+      root, "address", CONFIG_TYPE_GROUP, "Address for parcel delivery");
 
   setting = config_setting_add(group, "street", CONFIG_TYPE_STRING);
   config_setting_set_string(setting, "1 Woz Way");

--- a/lib/libconfig.c
+++ b/lib/libconfig.c
@@ -608,6 +608,13 @@ static void __config_write_setting(const config_t *config,
   char nongroup_assign_char = config_get_option(
     config, CONFIG_OPTION_COLON_ASSIGNMENT_FOR_NON_GROUPS) ? ':' : '=';
 
+  if(setting->comment)
+  {
+    if(depth > 1)
+      __config_indent(stream, depth, config->tab_width);
+    fprintf(stream, "// %s\n", setting->comment);
+  }
+
   if(depth > 1)
     __config_indent(stream, depth, config->tab_width);
 
@@ -824,7 +831,8 @@ void config_set_hook(config_t *config, void *hook)
 /* ------------------------------------------------------------------------- */
 
 static config_setting_t *config_setting_create(config_setting_t *parent,
-                                               const char *name, int type)
+                                               const char *name,
+                                               int type, const char *comment)
 {
   config_setting_t *setting;
   config_list_t *list;
@@ -839,6 +847,7 @@ static config_setting_t *config_setting_create(config_setting_t *parent,
   setting->config = parent->config;
   setting->hook = NULL;
   setting->line = 0;
+  setting->comment = (comment == NULL) ? NULL : strdup(comment);
 
   list = parent->value.list;
 
@@ -1343,7 +1352,7 @@ config_setting_t *config_setting_set_int_elem(config_setting_t *setting,
     if(! __config_list_checktype(setting, CONFIG_TYPE_INT))
       return(NULL);
 
-    element = config_setting_create(setting, NULL, CONFIG_TYPE_INT);
+    element = config_setting_create(setting, NULL, CONFIG_TYPE_INT, NULL);
   }
   else
   {
@@ -1385,7 +1394,7 @@ config_setting_t *config_setting_set_int64_elem(config_setting_t *setting,
     if(! __config_list_checktype(setting, CONFIG_TYPE_INT64))
       return(NULL);
 
-    element = config_setting_create(setting, NULL, CONFIG_TYPE_INT64);
+    element = config_setting_create(setting, NULL, CONFIG_TYPE_INT64, NULL);
   }
   else
   {
@@ -1426,7 +1435,7 @@ config_setting_t *config_setting_set_float_elem(config_setting_t *setting,
     if(! __config_list_checktype(setting, CONFIG_TYPE_FLOAT))
       return(NULL);
 
-    element = config_setting_create(setting, NULL, CONFIG_TYPE_FLOAT);
+    element = config_setting_create(setting, NULL, CONFIG_TYPE_FLOAT, NULL);
   }
   else
     element = config_setting_get_elem(setting, idx);
@@ -1471,7 +1480,7 @@ config_setting_t *config_setting_set_bool_elem(config_setting_t *setting,
     if(! __config_list_checktype(setting, CONFIG_TYPE_BOOL))
       return(NULL);
 
-    element = config_setting_create(setting, NULL, CONFIG_TYPE_BOOL);
+    element = config_setting_create(setting, NULL, CONFIG_TYPE_BOOL, NULL);
   }
   else
     element = config_setting_get_elem(setting, idx);
@@ -1517,7 +1526,7 @@ config_setting_t *config_setting_set_string_elem(config_setting_t *setting,
     if(! __config_list_checktype(setting, CONFIG_TYPE_STRING))
       return(NULL);
 
-    element = config_setting_create(setting, NULL, CONFIG_TYPE_STRING);
+    element = config_setting_create(setting, NULL, CONFIG_TYPE_STRING, NULL);
   }
   else
     element = config_setting_get_elem(setting, idx);
@@ -1535,7 +1544,7 @@ config_setting_t *config_setting_set_string_elem(config_setting_t *setting,
 
 config_setting_t *config_setting_get_elem(const config_setting_t *setting,
                                           unsigned int idx)
-{  
+{
   config_list_t *list;
 
   if(! config_setting_is_aggregate(setting))
@@ -1606,8 +1615,8 @@ void config_setting_set_hook(config_setting_t *setting, void *hook)
 
 /* ------------------------------------------------------------------------- */
 
-config_setting_t *config_setting_add(config_setting_t *parent,
-                                     const char *name, int type)
+config_setting_t *config_setting_add_with_comment(config_setting_t *parent,
+                            const char *name, int type, const char *comment)
 {
   if((type < CONFIG_TYPE_NONE) || (type > CONFIG_TYPE_LIST))
     return(NULL);
@@ -1635,7 +1644,15 @@ config_setting_t *config_setting_add(config_setting_t *parent,
       return(NULL); /* already exists */
   }
 
-  return(config_setting_create(parent, name, type));
+  return(config_setting_create(parent, name, type, comment));
+}
+
+/* ------------------------------------------------------------------------- */
+
+config_setting_t *config_setting_add(config_setting_t *parent,
+                                     const char *name, int type)
+{
+  config_setting_add_with_comment(parent, name, type, NULL);
 }
 
 /* ------------------------------------------------------------------------- */

--- a/lib/libconfig.h
+++ b/lib/libconfig.h
@@ -90,6 +90,7 @@ typedef struct config_setting_t
   void *hook;
   unsigned int line;
   const char *file;
+  char *comment;
 } config_setting_t;
 
 typedef enum
@@ -290,6 +291,8 @@ extern LIBCONFIG_API config_setting_t *config_setting_get_member(
 
 extern LIBCONFIG_API config_setting_t *config_setting_add(
   config_setting_t *parent, const char *name, int type);
+extern LIBCONFIG_API config_setting_t *config_setting_add_with_comment(
+  config_setting_t *parent, const char *name, int type, const char *comment);
 extern LIBCONFIG_API int config_setting_remove(config_setting_t *parent,
                                                const char *name);
 extern LIBCONFIG_API int config_setting_remove_elem(config_setting_t *parent,

--- a/lib/libconfig.h++
+++ b/lib/libconfig.h++
@@ -268,7 +268,7 @@ class LIBCONFIGXX_API Setting
 
   void remove(unsigned int idx);
 
-  Setting & add(const char *name, Type type);
+  Setting & add(const char *name, Type type, const char *comment = NULL);
 
   inline Setting & add(const std::string &name, Type type)
   { return(add(name.c_str(), type)); }

--- a/lib/libconfigcpp.c++
+++ b/lib/libconfigcpp.c++
@@ -1106,7 +1106,7 @@ void Setting::remove(unsigned int idx)
 
 // ---------------------------------------------------------------------------
 
-Setting & Setting::add(const char *name, Setting::Type type)
+Setting & Setting::add(const char *name, Setting::Type type, const char *comment)
 {
   assertType(TypeGroup);
 
@@ -1115,7 +1115,8 @@ Setting & Setting::add(const char *name, Setting::Type type)
   if(typecode == CONFIG_TYPE_NONE)
     throw SettingTypeException(*this, name);
 
-  config_setting_t *setting = config_setting_add(_setting, name, typecode);
+  config_setting_t *setting = config_setting_add_with_comment(
+                                _setting, name, typecode, comment);
 
   if(! setting)
     throw SettingNameException(*this, name);


### PR DESCRIPTION
This PR adds the functionality to optionally add comments while writing configs. This helps give the user an idea about what the setting is.

You can add comments to your settings by using the following API as demonstrated in the example3

For C: We have a new function to add settings
```c
  group = config_setting_add_with_comment(
      root, "address", CONFIG_TYPE_GROUP, "Address for parcel delivery");
```

For C++, we make use of polymorphism in C++
```c++
  Setting &address = root.add("address", Setting::TypeGroup, "Address for parcel delivery");
```

example3 produces the following output
```
// Address for parcel delivery
address :
{
  street = "1 Woz Way";
  city = "San Jose";
  state = "CA";
  zip = 95110;
};
numbers = [ 0, 10, 20, 30, 40, 50, 60, 70, 80, 90 ];
```