### PR TITLE
cmake: set VERSION + SOVERSION property on libraries

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -39,9 +39,13 @@ add_library(${libname}++ ${libsrc_cpp} ${libinc_cpp})
 
 set_target_properties(${libname}
     PROPERTIES LINKER_LANGUAGE C
+        SOVERSION "${libconfig_VERSION_MAJOR}"
+        VERSION "${libconfig_VERSION}"
         PUBLIC_HEADER "${libinc}")
 set_target_properties(${libname}++
     PROPERTIES LINKER_LANGUAGE CXX
+        SOVERSION "${libconfig_VERSION_MAJOR}"
+        VERSION "${libconfig_VERSION}"
         PUBLIC_HEADER "${libinc_cpp}")
 
 #check_symbol_exists(uselocale "locale.h" HAVE_USELOCALE)


### PR DESCRIPTION
Fixes #147

These properties are only active when the libraries are built as a shared library.

The install prefix looks like this:
```
prefix
├── include
│   ├── libconfig.h
│   ├── libconfig.h++
│   └── libconfig.hh
└── lib64
    ├── cmake
    │   └── libconfig
    │       ├── libconfig++Config.cmake
    │       ├── libconfigConfig.cmake
    │       ├── libconfig++Config-noconfig.cmake
    │       ├── libconfigConfig-noconfig.cmake
    │       ├── libconfig++ConfigVersion.cmake
    │       └── libconfigConfigVersion.cmake
    ├── libconfig++.so -> libconfig++.so.1
    ├── libconfig.so -> libconfig.so.1
    ├── libconfig++.so.1 -> libconfig++.so.1.7.2
    ├── libconfig.so.1 -> libconfig.so.1.7.2
    ├── libconfig++.so.1.7.2
    └── libconfig.so.1.7.2
```