### PR TITLE
add --disable-tests configure option

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,7 +1,7 @@
 
 ACLOCAL_AMFLAGS = -I m4
 
-SUBDIRS = lib tinytest tests
+SUBDIRS = lib
 
 if BUILDDOC
 SUBDIRS += doc
@@ -9,6 +9,10 @@ endif
 
 if BUILDEXAMPLES
 SUBDIRS += examples
+endif
+
+if BUILDTESTS
+SUBDIRS += tinytest tests
 endif
 
 .PHONY: dist-rpm

--- a/configure.ac
+++ b/configure.ac
@@ -123,6 +123,18 @@ doexamples=yes
 
 AM_CONDITIONAL(BUILDEXAMPLES, test x$doexamples = xyes)
 
+dotests=yes
+
+AC_ARG_ENABLE(tests,
+AS_HELP_STRING([--disable-tests], [Disable building of the tests]),
+[if test "$enableval" = "no"; then dotests="no"; fi],
+[
+dotests=yes
+]
+)
+
+AM_CONDITIONAL(BUILDTESTS, test x$dotests = xyes)
+
 dnl Check for MinGW. Workaround for libtool's DLL_EXPORT stupidity.
 
 case "$target" in


### PR DESCRIPTION
i was cross-compiling for windows statically, and the only thing that wasn't building were the tests. I am applying this patch locally to allow me to disable building the tests, so I figured I would upstream it.