### PR TITLE
Fix memory leak in example4.c

### DIFF
--- a/examples/c/example4.c
+++ b/examples/c/example4.c
@@ -132,6 +132,8 @@ int main(int argc, char **argv)
   }
 
   config_write(&cfg, stdout);
+   
+  config_destroy(&cfg);
 
   return(EXIT_SUCCESS);
 }


### PR DESCRIPTION
Found with ASan:
```
FAIL: example4                                                                                                                                               
  ==============                                                                                                                                               
                                                                                                                                                               
                                                                                                                                                               
  =================================================================                                                                                            
  ==4679==ERROR: LeakSanitizer: detected memory leaks                                                                                                          
                                                                                                                                                               
  Direct leak of 264 byte(s) in 1 object(s) allocated from:                                                                                                    
      #0 0x7ffff76ac1f8 in __interceptor_realloc (/nix/store/9ilyrqidrjbqvmnn8ykjc7lygdd86g7q-gcc-10.2.0-lib/lib/libasan.so.6+0xad1f8)                         
      #1 0x7ffff75f67a1 in strvec_append (/build/libconfig-1.7.2/lib/.libs/libconfig.so.11+0x1d7a1)                                                            
      #2 0x7ffff75e8b12 in scanctx_init (/build/libconfig-1.7.2/lib/.libs/libconfig.so.11+0xfb12)                                                              
      #3 0x7ffff75e451a in __config_read (/build/libconfig-1.7.2/lib/.libs/libconfig.so.11+0xb51a)                                                             
      #4 0x7ffff75e4e7e in config_read_file (/build/libconfig-1.7.2/lib/.libs/libconfig.so.11+0xbe7e)                                                          
      #5 0x401a9c in main (/build/libconfig-1.7.2/examples/c/.libs/lt-example4+0x401a9c)                                                                       
      #6 0x7ffff741edec in __libc_start_main (/nix/store/v8q6nxyppy1myi3rxni2080bv8s9jxiy-glibc-2.32-40/lib/libc.so.6+0x27dec)                                 
                                                                                                                                                               
  SUMMARY: AddressSanitizer: 264 byte(s) leaked in 1 allocation(s).                                             
```