### PR TITLE
Make sure function arguments are used

### DIFF
--- a/examples/c++/example1.cpp
+++ b/examples/c++/example1.cpp
@@ -33,6 +33,9 @@ using namespace libconfig;
 
 int main(int argc, char **argv)
 {
+  (void)argc;
+  (void)argv;
+
   Config cfg;
 
   // Read the file. If there is an error, report it and exit.

--- a/examples/c++/example2.cpp
+++ b/examples/c++/example2.cpp
@@ -34,6 +34,9 @@ using namespace libconfig;
 
 int main(int argc, char **argv)
 {
+  (void)argc;
+  (void)argv;
+
   static const char *output_file = "updated.cfg";
 
   Config cfg;

--- a/examples/c++/example3.cpp
+++ b/examples/c++/example3.cpp
@@ -33,6 +33,9 @@ using namespace libconfig;
 
 int main(int argc, char **argv)
 {
+  (void)argc;
+  (void)argv;
+
   static const char *output_file = "newconfig.cfg";
   Config cfg;
 

--- a/examples/c++/example4.cpp
+++ b/examples/c++/example4.cpp
@@ -33,6 +33,9 @@ using namespace libconfig;
 
 int main(int argc, char **argv)
 {
+  (void)argc;
+  (void)argv;
+
   Config cfg;
 
   try

--- a/lib/libconfigcpp.c++
+++ b/lib/libconfigcpp.c++
@@ -42,6 +42,7 @@ static const char **__include_func(config_t *config,
                                    const char *path,
                                    const char **error)
 {
+  (void)include_dir;
   Config *self = reinterpret_cast<Config *>(config_get_hook(config));
   return(self->evaluateIncludePath(path, error));
 }


### PR DESCRIPTION
This patch fixes this issue:
error: unused parameter 'argc' [-Werror=unused-parameter]