### PR TITLE
Windows fixes

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -62,7 +62,7 @@ if(BUILD_SHARED_LIBS)
     target_compile_definitions(${libname}++ PRIVATE LIBCONFIG_STATIC)
 else()
     target_compile_definitions(${libname} PUBLIC LIBCONFIG_STATIC)
-    target_compile_definitions(${libname}++ PUBLIC LIBCONFIGXX_STATIC)
+    target_compile_definitions(${libname}++ PUBLIC LIBCONFIGXX_STATIC PRIVATE LIBCONFIG_STATIC)
 endif()
 
 if(APPLE)

--- a/lib/libconfig.c
+++ b/lib/libconfig.c
@@ -47,6 +47,10 @@
 #include "scanner.h"
 #include "util.h"
 
+#if defined(_WIN32)
+#include <io.h>
+#endif
+
 #define PATH_TOKENS ":./"
 #define CHUNK_SIZE 16
 #define DEFAULT_TAB_WIDTH 2
@@ -700,7 +704,12 @@ int config_write_file(config_t *config, const char *filename)
 
     if(fd >= 0)
     {
-      if(fsync(fd) != 0)
+#if defined(_WIN32)
+      int fsync_res = _commit(fd);
+#else
+      int fsync_res = fsync(fd);
+#endif
+      if(fsync_res != 0)
       {
         fclose(stream);
         config->error_text = __io_error;

--- a/lib/libconfig.c
+++ b/lib/libconfig.c
@@ -83,8 +83,7 @@ static void __config_write_setting(const config_t *config,
 
 static void __config_locale_override(void)
 {
-#if (defined(WIN32) || defined(_WIN32) || defined(__WIN32__)) \
-  && ! defined(__MINGW32__)
+#if (defined(WIN32) || defined(_WIN32) || defined(__WIN32__))
 
   _configthreadlocale(_ENABLE_PER_THREAD_LOCALE);
   setlocale(LC_NUMERIC, "C");
@@ -110,8 +109,7 @@ static void __config_locale_override(void)
 
 static void __config_locale_restore(void)
 {
-#if (defined(WIN32) || defined(_WIN32) || defined(__WIN32__)) \
-  && ! defined(__MINGW32__)
+#if (defined(WIN32) || defined(_WIN32) || defined(__WIN32__))
 
     _configthreadlocale(_DISABLE_PER_THREAD_LOCALE);
 

--- a/tinytest/tinytest.c
+++ b/tinytest/tinytest.c
@@ -25,9 +25,11 @@
 #include <stdarg.h>
 #include <stdio.h>
 
-#ifdef WIN32
+#ifdef _WIN32
 #include <io.h>
+#ifndef F_OK
 #define F_OK 4  // Windows doesn't have F_OK
+#endif
 #else
 #include <unistd.h>
 #endif


### PR DESCRIPTION
These patches fixes building libconfig on mingw@Linux in static + shared configuration.

The following warnings are left when building with mingw:
```
[ 32%] Building C object lib/CMakeFiles/config.dir/libconfig.c.obj
/home/maarten/programming/libconfig/lib/libconfig.c: In function '__config_locale_override':
/home/maarten/programming/libconfig/lib/libconfig.c:100:2: warning: #warning "No way to modify calling thread's locale!" [-Wcpp]
  100 | #warning "No way to modify calling thread's locale!"
      |  ^~~~~~~
/home/maarten/programming/libconfig/lib/libconfig.c: In function '__config_locale_restore':
/home/maarten/programming/libconfig/lib/libconfig.c:121:2: warning: #warning "No way to modify calling thread's locale!" [-Wcpp]
  121 | #warning "No way to modify calling thread's locale!"
      |  ^~~~~~~
[ 91%] Building C object tinytest/CMakeFiles/libtinytest.dir/tinytest.c.obj
/home/maarten/programming/libconfig/tinytest/tinytest.c:30: warning: "F_OK" redefined
   30 | #define F_OK 4  // Windows doesn't have F_OK
      | 
In file included from /home/maarten/programming/libconfig/tinytest/tinytest.c:29:
/usr/x86_64-w64-mingw32/sys-root/mingw/include/io.h:182: note: this is the location of the previous definition
  182 | #define F_OK 0 /* Check for file existence */
      | 
```

FYI, documentation of [_commit](https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/commit?view=msvc-160) (=Windows's counterpart of fsync)

Update: all warnings on mingw are fixed (when building without `-Wall`.
There are some more when adding `-Wall -Wextra`, but I think these are out of scope for this pr.