### PR TITLE
fix build fail

### DIFF
--- a/ac_config.h.in
+++ b/ac_config.h.in
@@ -102,11 +102,6 @@
 #ifndef _HPUX_ALT_XOPEN_SOCKET_API
 # undef _HPUX_ALT_XOPEN_SOCKET_API
 #endif
-/* Identify the host operating system as Minix.
-   This macro does not affect the system headers' behavior.
-   A future release of Autoconf may stop defining this macro.  */
-#ifndef _MINIX
-# undef _MINIX
 #endif
 /* Enable general extensions on NetBSD.
    Enable NetBSD compatibility extensions on Minix.  */
@@ -175,6 +170,9 @@
 /* Define to 1 if `lex' declares `yytext' as a `char *' by default, not a
    `char[]'. */
 #undef YYTEXT_POINTER
+
+/* Define to 1 if on MINIX. */
+#undef _MINIX
 
 /* Define to empty if `const' does not conform to ANSI C. */
 #undef const


### PR DESCRIPTION
I use libconfig-1.7.3， gcc-10.3, automake 1.16.5, libconfig build success. But, when I use the patch command to apply 2c40b58, the libconfig build fails. The error information is as follows:
[  299s] + /usr/bin/make -O -j16 V=1 VERBOSE=1
[  299s] CDPATH="${ZSH_VERSION+.}:" && cd . && /bin/sh /home/abuild/rpmbuild/BUILD/libconfig-1.7.3/aux-build/missing aclocal-1.15 -I m4 [  299s] /home/abuild/rpmbuild/BUILD/libconfig-1.7.3/aux-build/missing: line 81: aclocal-1.15: command not found [  299s] WARNING: 'aclocal-1.15' is missing on your system.


https://github.com/hyperrealm/libconfig/issues/225