### PR TITLE
Add support for binary integer values

### DIFF
--- a/doc/libconfig.texi
+++ b/doc/libconfig.texi
@@ -514,7 +514,7 @@ Integers can be represented in one of two ways: as a series of one or more
 decimal digits (@samp{0} - @samp{9}), with an optional leading sign character
 (@samp{+} or @samp{-}); as a hexadecimal value consisting of the characters
 @samp{0x} followed by a series of one or more hexadecimal digits (@samp{0} -
-@samp{9}, @samp{A} - @samp{F}, @samp{a} - @samp{f}); or (as of version 1.7.3 of
+@samp{9}, @samp{A} - @samp{F}, @samp{a} - @samp{f}); or (as of version 1.7.4 of
 the library) as a binary value consisting of the characters @samp{0b} followed
 by a series of @samp{0}s or @samp{1}s. Additionally, octal notation integers
 (that is, those having a leading zero with non-zero value) are also allowed.

--- a/doc/libconfig.texi
+++ b/doc/libconfig.texi
@@ -404,6 +404,7 @@ application:
     bigint = 9223372036854775807L;
     columns = [ "Last Name", "First Name", "MI" ];
     bitmask = 0x1FC3;	// hex
+    bitmask2 = 0b1011; // binary
     umask = 0027;	// octal. Range limited to that of "int"
   @};
 @};
@@ -509,24 +510,26 @@ The last element in a list may be followed by a comma, which will be ignored.
 @comment  node-name,  next,  previous,  up
 @section Integer Values
 
-Integers can be represented in one of two ways: as a series of one or
-more decimal digits (@samp{0} - @samp{9}), with an optional leading
-sign character (@samp{+} or @samp{-}); or as a hexadecimal value
-consisting of the characters @samp{0x} followed by a series of one or
-more hexadecimal digits (@samp{0} - @samp{9}, @samp{A} - @samp{F},
-@samp{a} - @samp{f}). Additionally, octal notation integers (that is,
-those having a leading zero with non-zero value) are also allowed.
+Integers can be represented in one of two ways: as a series of one or more
+decimal digits (@samp{0} - @samp{9}), with an optional leading sign character
+(@samp{+} or @samp{-}); as a hexadecimal value consisting of the characters
+@samp{0x} followed by a series of one or more hexadecimal digits (@samp{0} -
+@samp{9}, @samp{A} - @samp{F}, @samp{a} - @samp{f}); or (as of version 1.7.3 of
+the library) as a binary value consisting of the characters @samp{0b} followed
+by a series of @samp{0}s or @samp{1}s. Additionally, octal notation integers
+(that is, those having a leading zero with non-zero value) are also allowed.
 
 @node 64-bit Integer Values, Floating Point Values, Integer Values, Configuration Files
 @comment  node-name,  next,  previous,  up
 @section 64-bit Integer Values
 
-Long long (64-bit) integers are represented identically to integers,
-except that an `L' character is appended to indicate a 64-bit
-value. For example, @samp{0L} indicates a 64-bit integer value 0.  As
-of version 1.5 of the library, the trailing `L' is optional; if the
-integer value exceeds the range of a 32-bit integer, it will
-automatically be interpreted as a 64-bit integer.
+Long long (64-bit) integers are represented identically to integers, except
+that an `L' character is appended to indicate a 64-bit value. For example,
+@samp{0L} indicates a 64-bit integer value 0.  As of version 1.5 of the
+library, the trailing `L' is optional; if the integer value exceeds the range
+of a 32-bit integer, it will automatically be interpreted as a 64-bit integer.
+As of version 1.7.4 of the library this behavior is extended to hexadecimal
+(and binary) integers as well.
 
 The @i{integer} and @i{64-bit integer} setting types are interchangeable to the
 extent that a conversion between the corresponding native types would not
@@ -2464,6 +2467,8 @@ directives are not part of the grammar, so they are not included here.
       <boolean>
     | <integer>
     | <integer64>
+    | <bin>
+    | <bin64>
     | <hex>
     | <hex64>
     | <float>
@@ -2501,6 +2506,10 @@ Terminals are defined below as regular expressions:
 @code{[-+]?[0-9]+}
 @item @code{<integer64>} @tab
 @code{[-+]?[0-9]+L(L)?}
+@item @code{<bin>} @tab
+@code{0[bB][01]+}
+@item @code{<bin64>} @tab
+@code{0[bB][01]+L(L)?}
 @item @code{<hex>} @tab
 @code{0[Xx][0-9A-Fa-f]+}
 @item @code{<hex64>} @tab

--- a/lib/grammar.c
+++ b/lib/grammar.c
@@ -1,4 +1,4 @@
-/* A Bison parser, made by GNU Bison 3.8.  */
+/* A Bison parser, made by GNU Bison 3.8.2.  */
 
 /* Bison implementation for Yacc-like parsers in C
 
@@ -46,10 +46,10 @@
    USER NAME SPACE" below.  */
 
 /* Identify Bison output, and Bison version.  */
-#define YYBISON 30800
+#define YYBISON 30802
 
 /* Bison version string.  */
-#define YYBISON_VERSION "3.8"
+#define YYBISON_VERSION "3.8.2"
 
 /* Skeleton name.  */
 #define YYSKELETON_NAME "yacc.c"
@@ -146,7 +146,7 @@ void libconfig_yyerror(void *scanner, struct parse_context *ctx,
 # define YY_LIBCONFIG_YY_GRAMMAR_H_INCLUDED
 /* Debug traces.  */
 #ifndef YYDEBUG
-# define YYDEBUG 0
+# define YYDEBUG 1
 #endif
 #if YYDEBUG
 extern int libconfig_yydebug;
@@ -164,23 +164,25 @@ extern int libconfig_yydebug;
     TOK_BOOLEAN = 258,             /* TOK_BOOLEAN  */
     TOK_INTEGER = 259,             /* TOK_INTEGER  */
     TOK_HEX = 260,                 /* TOK_HEX  */
-    TOK_INTEGER64 = 261,           /* TOK_INTEGER64  */
-    TOK_HEX64 = 262,               /* TOK_HEX64  */
-    TOK_FLOAT = 263,               /* TOK_FLOAT  */
-    TOK_STRING = 264,              /* TOK_STRING  */
-    TOK_NAME = 265,                /* TOK_NAME  */
-    TOK_EQUALS = 266,              /* TOK_EQUALS  */
-    TOK_NEWLINE = 267,             /* TOK_NEWLINE  */
-    TOK_ARRAY_START = 268,         /* TOK_ARRAY_START  */
-    TOK_ARRAY_END = 269,           /* TOK_ARRAY_END  */
-    TOK_LIST_START = 270,          /* TOK_LIST_START  */
-    TOK_LIST_END = 271,            /* TOK_LIST_END  */
-    TOK_COMMA = 272,               /* TOK_COMMA  */
-    TOK_GROUP_START = 273,         /* TOK_GROUP_START  */
-    TOK_GROUP_END = 274,           /* TOK_GROUP_END  */
-    TOK_SEMICOLON = 275,           /* TOK_SEMICOLON  */
-    TOK_GARBAGE = 276,             /* TOK_GARBAGE  */
-    TOK_ERROR = 277                /* TOK_ERROR  */
+    TOK_BIN = 261,                 /* TOK_BIN  */
+    TOK_INTEGER64 = 262,           /* TOK_INTEGER64  */
+    TOK_HEX64 = 263,               /* TOK_HEX64  */
+    TOK_BIN64 = 264,               /* TOK_BIN64  */
+    TOK_FLOAT = 265,               /* TOK_FLOAT  */
+    TOK_STRING = 266,              /* TOK_STRING  */
+    TOK_NAME = 267,                /* TOK_NAME  */
+    TOK_EQUALS = 268,              /* TOK_EQUALS  */
+    TOK_NEWLINE = 269,             /* TOK_NEWLINE  */
+    TOK_ARRAY_START = 270,         /* TOK_ARRAY_START  */
+    TOK_ARRAY_END = 271,           /* TOK_ARRAY_END  */
+    TOK_LIST_START = 272,          /* TOK_LIST_START  */
+    TOK_LIST_END = 273,            /* TOK_LIST_END  */
+    TOK_COMMA = 274,               /* TOK_COMMA  */
+    TOK_GROUP_START = 275,         /* TOK_GROUP_START  */
+    TOK_GROUP_END = 276,           /* TOK_GROUP_END  */
+    TOK_SEMICOLON = 277,           /* TOK_SEMICOLON  */
+    TOK_GARBAGE = 278,             /* TOK_GARBAGE  */
+    TOK_ERROR = 279                /* TOK_ERROR  */
   };
   typedef enum yytokentype yytoken_kind_t;
 #endif
@@ -192,23 +194,25 @@ extern int libconfig_yydebug;
 #define TOK_BOOLEAN 258
 #define TOK_INTEGER 259
 #define TOK_HEX 260
-#define TOK_INTEGER64 261
-#define TOK_HEX64 262
-#define TOK_FLOAT 263
-#define TOK_STRING 264
-#define TOK_NAME 265
-#define TOK_EQUALS 266
-#define TOK_NEWLINE 267
-#define TOK_ARRAY_START 268
-#define TOK_ARRAY_END 269
-#define TOK_LIST_START 270
-#define TOK_LIST_END 271
-#define TOK_COMMA 272
-#define TOK_GROUP_START 273
-#define TOK_GROUP_END 274
-#define TOK_SEMICOLON 275
-#define TOK_GARBAGE 276
-#define TOK_ERROR 277
+#define TOK_BIN 261
+#define TOK_INTEGER64 262
+#define TOK_HEX64 263
+#define TOK_BIN64 264
+#define TOK_FLOAT 265
+#define TOK_STRING 266
+#define TOK_NAME 267
+#define TOK_EQUALS 268
+#define TOK_NEWLINE 269
+#define TOK_ARRAY_START 270
+#define TOK_ARRAY_END 271
+#define TOK_LIST_START 272
+#define TOK_LIST_END 273
+#define TOK_COMMA 274
+#define TOK_GROUP_START 275
+#define TOK_GROUP_END 276
+#define TOK_SEMICOLON 277
+#define TOK_GARBAGE 278
+#define TOK_ERROR 279
 
 /* Value type.  */
 #if ! defined YYSTYPE && ! defined YYSTYPE_IS_DECLARED
@@ -221,7 +225,7 @@ union YYSTYPE
   double fval;
   char *sval;
 
-#line 225 "grammar.c"
+#line 229 "grammar.c"
 
 };
 typedef union YYSTYPE YYSTYPE;
@@ -231,12 +235,6 @@ typedef union YYSTYPE YYSTYPE;
 
 
 
-#if !defined libconfig_yyerror && !defined YYERROR_IS_DECLARED
-void libconfig_yyerror (void *scanner, struct parse_context *ctx, struct scan_context *scan_ctx, const char *msg);
-#endif
-#if !defined libconfig_yylex && !defined YYLEX_IS_DECLARED
-int libconfig_yylex (YYSTYPE *yylvalp, void *scanner);
-#endif
 
 int libconfig_yyparse (void *scanner, struct parse_context *ctx, struct scan_context *scan_ctx);
 
@@ -252,43 +250,45 @@ enum yysymbol_kind_t
   YYSYMBOL_TOK_BOOLEAN = 3,                /* TOK_BOOLEAN  */
   YYSYMBOL_TOK_INTEGER = 4,                /* TOK_INTEGER  */
   YYSYMBOL_TOK_HEX = 5,                    /* TOK_HEX  */
-  YYSYMBOL_TOK_INTEGER64 = 6,              /* TOK_INTEGER64  */
-  YYSYMBOL_TOK_HEX64 = 7,                  /* TOK_HEX64  */
-  YYSYMBOL_TOK_FLOAT = 8,                  /* TOK_FLOAT  */
-  YYSYMBOL_TOK_STRING = 9,                 /* TOK_STRING  */
-  YYSYMBOL_TOK_NAME = 10,                  /* TOK_NAME  */
-  YYSYMBOL_TOK_EQUALS = 11,                /* TOK_EQUALS  */
-  YYSYMBOL_TOK_NEWLINE = 12,               /* TOK_NEWLINE  */
-  YYSYMBOL_TOK_ARRAY_START = 13,           /* TOK_ARRAY_START  */
-  YYSYMBOL_TOK_ARRAY_END = 14,             /* TOK_ARRAY_END  */
-  YYSYMBOL_TOK_LIST_START = 15,            /* TOK_LIST_START  */
-  YYSYMBOL_TOK_LIST_END = 16,              /* TOK_LIST_END  */
-  YYSYMBOL_TOK_COMMA = 17,                 /* TOK_COMMA  */
-  YYSYMBOL_TOK_GROUP_START = 18,           /* TOK_GROUP_START  */
-  YYSYMBOL_TOK_GROUP_END = 19,             /* TOK_GROUP_END  */
-  YYSYMBOL_TOK_SEMICOLON = 20,             /* TOK_SEMICOLON  */
-  YYSYMBOL_TOK_GARBAGE = 21,               /* TOK_GARBAGE  */
-  YYSYMBOL_TOK_ERROR = 22,                 /* TOK_ERROR  */
-  YYSYMBOL_YYACCEPT = 23,                  /* $accept  */
-  YYSYMBOL_configuration = 24,             /* configuration  */
-  YYSYMBOL_setting_list = 25,              /* setting_list  */
-  YYSYMBOL_setting_list_optional = 26,     /* setting_list_optional  */
-  YYSYMBOL_setting_terminator = 27,        /* setting_terminator  */
-  YYSYMBOL_setting = 28,                   /* setting  */
-  YYSYMBOL_29_1 = 29,                      /* $@1  */
-  YYSYMBOL_array = 30,                     /* array  */
-  YYSYMBOL_31_2 = 31,                      /* $@2  */
-  YYSYMBOL_list = 32,                      /* list  */
-  YYSYMBOL_33_3 = 33,                      /* $@3  */
-  YYSYMBOL_value = 34,                     /* value  */
-  YYSYMBOL_string = 35,                    /* string  */
-  YYSYMBOL_simple_value = 36,              /* simple_value  */
-  YYSYMBOL_value_list = 37,                /* value_list  */
-  YYSYMBOL_value_list_optional = 38,       /* value_list_optional  */
-  YYSYMBOL_simple_value_list = 39,         /* simple_value_list  */
-  YYSYMBOL_simple_value_list_optional = 40, /* simple_value_list_optional  */
-  YYSYMBOL_group = 41,                     /* group  */
-  YYSYMBOL_42_4 = 42                       /* $@4  */
+  YYSYMBOL_TOK_BIN = 6,                    /* TOK_BIN  */
+  YYSYMBOL_TOK_INTEGER64 = 7,              /* TOK_INTEGER64  */
+  YYSYMBOL_TOK_HEX64 = 8,                  /* TOK_HEX64  */
+  YYSYMBOL_TOK_BIN64 = 9,                  /* TOK_BIN64  */
+  YYSYMBOL_TOK_FLOAT = 10,                 /* TOK_FLOAT  */
+  YYSYMBOL_TOK_STRING = 11,                /* TOK_STRING  */
+  YYSYMBOL_TOK_NAME = 12,                  /* TOK_NAME  */
+  YYSYMBOL_TOK_EQUALS = 13,                /* TOK_EQUALS  */
+  YYSYMBOL_TOK_NEWLINE = 14,               /* TOK_NEWLINE  */
+  YYSYMBOL_TOK_ARRAY_START = 15,           /* TOK_ARRAY_START  */
+  YYSYMBOL_TOK_ARRAY_END = 16,             /* TOK_ARRAY_END  */
+  YYSYMBOL_TOK_LIST_START = 17,            /* TOK_LIST_START  */
+  YYSYMBOL_TOK_LIST_END = 18,              /* TOK_LIST_END  */
+  YYSYMBOL_TOK_COMMA = 19,                 /* TOK_COMMA  */
+  YYSYMBOL_TOK_GROUP_START = 20,           /* TOK_GROUP_START  */
+  YYSYMBOL_TOK_GROUP_END = 21,             /* TOK_GROUP_END  */
+  YYSYMBOL_TOK_SEMICOLON = 22,             /* TOK_SEMICOLON  */
+  YYSYMBOL_TOK_GARBAGE = 23,               /* TOK_GARBAGE  */
+  YYSYMBOL_TOK_ERROR = 24,                 /* TOK_ERROR  */
+  YYSYMBOL_YYACCEPT = 25,                  /* $accept  */
+  YYSYMBOL_configuration = 26,             /* configuration  */
+  YYSYMBOL_setting_list = 27,              /* setting_list  */
+  YYSYMBOL_setting_list_optional = 28,     /* setting_list_optional  */
+  YYSYMBOL_setting_terminator = 29,        /* setting_terminator  */
+  YYSYMBOL_setting = 30,                   /* setting  */
+  YYSYMBOL_31_1 = 31,                      /* $@1  */
+  YYSYMBOL_array = 32,                     /* array  */
+  YYSYMBOL_33_2 = 33,                      /* $@2  */
+  YYSYMBOL_list = 34,                      /* list  */
+  YYSYMBOL_35_3 = 35,                      /* $@3  */
+  YYSYMBOL_value = 36,                     /* value  */
+  YYSYMBOL_string = 37,                    /* string  */
+  YYSYMBOL_simple_value = 38,              /* simple_value  */
+  YYSYMBOL_value_list = 39,                /* value_list  */
+  YYSYMBOL_value_list_optional = 40,       /* value_list_optional  */
+  YYSYMBOL_simple_value_list = 41,         /* simple_value_list  */
+  YYSYMBOL_simple_value_list_optional = 42, /* simple_value_list_optional  */
+  YYSYMBOL_group = 43,                     /* group  */
+  YYSYMBOL_44_4 = 44                       /* $@4  */
 };
 typedef enum yysymbol_kind_t yysymbol_kind_t;
 
@@ -616,19 +616,19 @@ union yyalloc
 /* YYFINAL -- State number of the termination state.  */
 #define YYFINAL  6
 /* YYLAST -- Last index in YYTABLE.  */
-#define YYLAST   35
+#define YYLAST   39
 
 /* YYNTOKENS -- Number of terminals.  */
-#define YYNTOKENS  23
+#define YYNTOKENS  25
 /* YYNNTS -- Number of nonterminals.  */
 #define YYNNTS  20
 /* YYNRULES -- Number of rules.  */
-#define YYNRULES  41
+#define YYNRULES  43
 /* YYNSTATES -- Number of states.  */
-#define YYNSTATES  47
+#define YYNSTATES  49
 
 /* YYMAXUTOK -- Last valid token kind.  */
-#define YYMAXUTOK   277
+#define YYMAXUTOK   279
 
 
 /* YYTRANSLATE(TOKEN-NUM) -- Symbol number corresponding to TOKEN-NUM
@@ -669,7 +669,7 @@ static const yytype_int8 yytranslate[] =
        2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
        2,     2,     2,     2,     2,     2,     1,     2,     3,     4,
        5,     6,     7,     8,     9,    10,    11,    12,    13,    14,
-      15,    16,    17,    18,    19,    20,    21,    22
+      15,    16,    17,    18,    19,    20,    21,    22,    23,    24
 };
 
 #if YYDEBUG
@@ -678,9 +678,9 @@ static const yytype_int16 yyrline[] =
 {
        0,    94,    94,    96,   100,   101,   104,   106,   109,   111,
      112,   117,   116,   136,   135,   159,   158,   181,   182,   183,
-     184,   188,   189,   193,   213,   235,   257,   279,   301,   319,
-     347,   348,   349,   352,   354,   358,   359,   360,   363,   365,
-     370,   369
+     184,   188,   189,   193,   213,   235,   257,   279,   301,   323,
+     345,   363,   391,   392,   393,   396,   398,   402,   403,   404,
+     407,   409,   414,   413
 };
 #endif
 
@@ -697,15 +697,15 @@ static const char *yysymbol_name (yysymbol_kind_t yysymbol) YY_ATTRIBUTE_UNUSED;
 static const char *const yytname[] =
 {
   "\"end of file\"", "error", "\"invalid token\"", "TOK_BOOLEAN",
-  "TOK_INTEGER", "TOK_HEX", "TOK_INTEGER64", "TOK_HEX64", "TOK_FLOAT",
-  "TOK_STRING", "TOK_NAME", "TOK_EQUALS", "TOK_NEWLINE", "TOK_ARRAY_START",
-  "TOK_ARRAY_END", "TOK_LIST_START", "TOK_LIST_END", "TOK_COMMA",
-  "TOK_GROUP_START", "TOK_GROUP_END", "TOK_SEMICOLON", "TOK_GARBAGE",
-  "TOK_ERROR", "$accept", "configuration", "setting_list",
-  "setting_list_optional", "setting_terminator", "setting", "$@1", "array",
-  "$@2", "list", "$@3", "value", "string", "simple_value", "value_list",
-  "value_list_optional", "simple_value_list", "simple_value_list_optional",
-  "group", "$@4", YY_NULLPTR
+  "TOK_INTEGER", "TOK_HEX", "TOK_BIN", "TOK_INTEGER64", "TOK_HEX64",
+  "TOK_BIN64", "TOK_FLOAT", "TOK_STRING", "TOK_NAME", "TOK_EQUALS",
+  "TOK_NEWLINE", "TOK_ARRAY_START", "TOK_ARRAY_END", "TOK_LIST_START",
+  "TOK_LIST_END", "TOK_COMMA", "TOK_GROUP_START", "TOK_GROUP_END",
+  "TOK_SEMICOLON", "TOK_GARBAGE", "TOK_ERROR", "$accept", "configuration",
+  "setting_list", "setting_list_optional", "setting_terminator", "setting",
+  "$@1", "array", "$@2", "list", "$@3", "value", "string", "simple_value",
+  "value_list", "value_list_optional", "simple_value_list",
+  "simple_value_list_optional", "group", "$@4", YY_NULLPTR
 };
 
 static const char *
@@ -715,7 +715,7 @@ yysymbol_name (yysymbol_kind_t yysymbol)
 }
 #endif
 
-#define YYPACT_NINF (-26)
+#define YYPACT_NINF (-19)
 
 #define yypact_value_is_default(Yyn) \
   ((Yyn) == YYPACT_NINF)
@@ -729,11 +729,11 @@ yysymbol_name (yysymbol_kind_t yysymbol)
    STATE-NUM.  */
 static const yytype_int8 yypact[] =
 {
-      -8,   -26,    12,    -8,   -26,     5,   -26,   -26,     0,   -26,
-     -26,   -26,   -26,   -26,   -26,   -26,   -26,   -26,   -26,   -26,
-     -26,    -6,    10,   -26,   -26,    23,     0,    -8,   -26,   -26,
-     -26,   -26,   -26,     3,     7,   -26,     6,     8,    -8,    14,
-      23,   -26,     0,   -26,   -26,   -26,   -26
+       4,   -19,    17,     4,   -19,     6,   -19,   -19,    -2,   -19,
+     -19,   -19,   -19,   -19,   -19,   -19,   -19,   -19,   -19,   -19,
+     -19,   -19,   -19,    -8,     9,   -19,   -19,    25,    -2,     4,
+     -19,   -19,   -19,   -19,   -19,     2,     7,   -19,     3,    20,
+       4,    18,    25,   -19,    -2,   -19,   -19,   -19,   -19
 };
 
 /* YYDEFACT[STATE-NUM] -- Default reduction number in state STATE-NUM.
@@ -742,24 +742,24 @@ static const yytype_int8 yypact[] =
 static const yytype_int8 yydefact[] =
 {
        2,    11,     0,     3,     4,     0,     1,     5,     0,    23,
-      24,    26,    25,    27,    28,    21,    13,    15,    40,    18,
-      19,     8,    29,    17,    20,    38,    33,     6,    10,     9,
-      12,    22,    35,    39,     0,    30,    34,     0,     7,     0,
-      37,    14,    32,    16,    41,    36,    31
+      24,    26,    28,    25,    27,    29,    30,    21,    13,    15,
+      42,    18,    19,     8,    31,    17,    20,    40,    35,     6,
+      10,     9,    12,    22,    37,    41,     0,    32,    36,     0,
+       7,     0,    39,    14,    34,    16,    43,    38,    33
 };
 
 /* YYPGOTO[NTERM-NUM].  */
 static const yytype_int8 yypgoto[] =
 {
-     -26,   -26,    -5,   -26,   -26,    -3,   -26,   -26,   -26,   -26,
-     -26,   -25,   -26,   -15,   -26,   -26,   -26,   -26,   -26,   -26
+     -19,   -19,    -5,   -19,   -19,    -3,   -19,   -19,   -19,   -19,
+     -19,   -18,   -19,   -15,   -19,   -19,   -19,   -19,   -19,   -19
 };
 
 /* YYDEFGOTO[NTERM-NUM].  */
 static const yytype_int8 yydefgoto[] =
 {
-       0,     2,     3,    39,    30,     4,     5,    19,    25,    20,
-      26,    21,    22,    23,    36,    37,    33,    34,    24,    27
+       0,     2,     3,    41,    32,     4,     5,    21,    27,    22,
+      28,    23,    24,    25,    38,    39,    35,    36,    26,    29
 };
 
 /* YYTABLE[YYPACT[STATE-NUM]] -- What to do in state STATE-NUM.  If
@@ -767,39 +767,39 @@ static const yytype_int8 yydefgoto[] =
    number is the opposite.  If YYTABLE_NINF, syntax error.  */
 static const yytype_int8 yytable[] =
 {
-       7,    35,     1,     9,    10,    11,    12,    13,    14,    15,
-      32,    28,     6,    16,    29,    17,     8,    46,    18,    31,
-      40,    41,    38,    42,    43,    45,     9,    10,    11,    12,
-      13,    14,    15,    44,     0,     7
+       7,     9,    10,    11,    12,    13,    14,    15,    16,    17,
+      37,    30,    34,    18,    31,    19,     1,     6,    20,     8,
+      33,    42,    44,    43,    40,     0,    48,    47,     9,    10,
+      11,    12,    13,    14,    15,    16,    17,     7,    45,    46
 };
 
 static const yytype_int8 yycheck[] =
 {
-       3,    26,    10,     3,     4,     5,     6,     7,     8,     9,
-      25,    17,     0,    13,    20,    15,    11,    42,    18,     9,
-      17,    14,    27,    17,    16,    40,     3,     4,     5,     6,
-       7,     8,     9,    19,    -1,    38
+       3,     3,     4,     5,     6,     7,     8,     9,    10,    11,
+      28,    19,    27,    15,    22,    17,    12,     0,    20,    13,
+      11,    19,    19,    16,    29,    -1,    44,    42,     3,     4,
+       5,     6,     7,     8,     9,    10,    11,    40,    18,    21
 };
 
 /* YYSTOS[STATE-NUM] -- The symbol kind of the accessing symbol of
    state STATE-NUM.  */
 static const yytype_int8 yystos[] =
 {
-       0,    10,    24,    25,    28,    29,     0,    28,    11,     3,
-       4,     5,     6,     7,     8,     9,    13,    15,    18,    30,
-      32,    34,    35,    36,    41,    31,    33,    42,    17,    20,
-      27,     9,    36,    39,    40,    34,    37,    38,    25,    26,
-      17,    14,    17,    16,    19,    36,    34
+       0,    12,    26,    27,    30,    31,     0,    30,    13,     3,
+       4,     5,     6,     7,     8,     9,    10,    11,    15,    17,
+      20,    32,    34,    36,    37,    38,    43,    33,    35,    44,
+      19,    22,    29,    11,    38,    41,    42,    36,    39,    40,
+      27,    28,    19,    16,    19,    18,    21,    38,    36
 };
 
 /* YYR1[RULE-NUM] -- Symbol kind of the left-hand side of rule RULE-NUM.  */
 static const yytype_int8 yyr1[] =
 {
-       0,    23,    24,    24,    25,    25,    26,    26,    27,    27,
-      27,    29,    28,    31,    30,    33,    32,    34,    34,    34,
-      34,    35,    35,    36,    36,    36,    36,    36,    36,    36,
-      37,    37,    37,    38,    38,    39,    39,    39,    40,    40,
-      42,    41
+       0,    25,    26,    26,    27,    27,    28,    28,    29,    29,
+      29,    31,    30,    33,    32,    35,    34,    36,    36,    36,
+      36,    37,    37,    38,    38,    38,    38,    38,    38,    38,
+      38,    38,    39,    39,    39,    40,    40,    41,    41,    41,
+      42,    42,    44,    43
 };
 
 /* YYR2[RULE-NUM] -- Number of symbols on the right-hand side of rule RULE-NUM.  */
@@ -808,8 +808,8 @@ static const yytype_int8 yyr2[] =
        0,     2,     0,     1,     1,     2,     0,     1,     0,     1,
        1,     0,     5,     0,     4,     0,     4,     1,     1,     1,
        1,     1,     2,     1,     1,     1,     1,     1,     1,     1,
-       1,     3,     2,     0,     1,     1,     3,     2,     0,     1,
-       0,     4
+       1,     1,     1,     3,     2,     0,     1,     1,     3,     2,
+       0,     1,     0,     4
 };
 
 
@@ -1506,8 +1506,60 @@ yyreduce:
 #line 1507 "grammar.c"
     break;
 
-  case 28: /* simple_value: TOK_FLOAT  */
+  case 28: /* simple_value: TOK_BIN  */
 #line 302 "grammar.y"
+  {
+    if(IN_ARRAY() || IN_LIST())
+    {
+      config_setting_t *e = config_setting_set_int_elem(ctx->parent, -1, (yyvsp[0].ival));
+      if(! e)
+      {
+        libconfig_yyerror(scanner, ctx, scan_ctx, err_array_elem_type);
+        YYABORT;
+      }
+      else
+      {
+        config_setting_set_format(e, CONFIG_FORMAT_BIN);
+        CAPTURE_PARSE_POS(e);
+      }
+    }
+    else
+    {
+      config_setting_set_int(ctx->setting, (yyvsp[0].ival));
+      config_setting_set_format(ctx->setting, CONFIG_FORMAT_BIN);
+    }
+  }
+#line 1533 "grammar.c"
+    break;
+
+  case 29: /* simple_value: TOK_BIN64  */
+#line 324 "grammar.y"
+  {
+    if(IN_ARRAY() || IN_LIST())
+    {
+      config_setting_t *e = config_setting_set_int64_elem(ctx->parent, -1, (yyvsp[0].llval));
+      if(! e)
+      {
+        libconfig_yyerror(scanner, ctx, scan_ctx, err_array_elem_type);
+        YYABORT;
+      }
+      else
+      {
+        config_setting_set_format(e, CONFIG_FORMAT_BIN);
+        CAPTURE_PARSE_POS(e);
+      }
+    }
+    else
+    {
+      config_setting_set_int64(ctx->setting, (yyvsp[0].llval));
+      config_setting_set_format(ctx->setting, CONFIG_FORMAT_BIN);
+    }
+  }
+#line 1559 "grammar.c"
+    break;
+
+  case 30: /* simple_value: TOK_FLOAT  */
+#line 346 "grammar.y"
   {
     if(IN_ARRAY() || IN_LIST())
     {
@@ -1525,11 +1577,11 @@ yyreduce:
     else
       config_setting_set_float(ctx->setting, (yyvsp[0].fval));
   }
-#line 1529 "grammar.c"
+#line 1581 "grammar.c"
     break;
 
-  case 29: /* simple_value: string  */
-#line 320 "grammar.y"
+  case 31: /* simple_value: string  */
+#line 364 "grammar.y"
   {
     if(IN_ARRAY() || IN_LIST())
     {
@@ -1554,11 +1606,11 @@ yyreduce:
       __delete(s);
     }
   }
-#line 1558 "grammar.c"
+#line 1610 "grammar.c"
     break;
 
-  case 40: /* $@4: %empty  */
-#line 370 "grammar.y"
+  case 42: /* $@4: %empty  */
+#line 414 "grammar.y"
   {
     if(IN_LIST())
     {
@@ -1572,20 +1624,20 @@ yyreduce:
       ctx->setting = NULL;
     }
   }
-#line 1576 "grammar.c"
+#line 1628 "grammar.c"
     break;
 
-  case 41: /* group: TOK_GROUP_START $@4 setting_list_optional TOK_GROUP_END  */
-#line 385 "grammar.y"
+  case 43: /* group: TOK_GROUP_START $@4 setting_list_optional TOK_GROUP_END  */
+#line 429 "grammar.y"
   {
     if(ctx->parent)
       ctx->parent = ctx->parent->parent;
   }
-#line 1585 "grammar.c"
+#line 1637 "grammar.c"
     break;
 
 
-#line 1589 "grammar.c"
+#line 1641 "grammar.c"
 
       default: break;
     }
@@ -1778,5 +1830,5 @@ yyreturnlab:
   return yyresult;
 }
 
-#line 391 "grammar.y"
+#line 435 "grammar.y"
 

--- a/lib/grammar.h
+++ b/lib/grammar.h
@@ -1,4 +1,4 @@
-/* A Bison parser, made by GNU Bison 3.8.  */
+/* A Bison parser, made by GNU Bison 3.8.2.  */
 
 /* Bison interface for Yacc-like parsers in C
 
@@ -39,7 +39,7 @@
 # define YY_LIBCONFIG_YY_GRAMMAR_H_INCLUDED
 /* Debug traces.  */
 #ifndef YYDEBUG
-# define YYDEBUG 0
+# define YYDEBUG 1
 #endif
 #if YYDEBUG
 extern int libconfig_yydebug;
@@ -57,23 +57,25 @@ extern int libconfig_yydebug;
     TOK_BOOLEAN = 258,             /* TOK_BOOLEAN  */
     TOK_INTEGER = 259,             /* TOK_INTEGER  */
     TOK_HEX = 260,                 /* TOK_HEX  */
-    TOK_INTEGER64 = 261,           /* TOK_INTEGER64  */
-    TOK_HEX64 = 262,               /* TOK_HEX64  */
-    TOK_FLOAT = 263,               /* TOK_FLOAT  */
-    TOK_STRING = 264,              /* TOK_STRING  */
-    TOK_NAME = 265,                /* TOK_NAME  */
-    TOK_EQUALS = 266,              /* TOK_EQUALS  */
-    TOK_NEWLINE = 267,             /* TOK_NEWLINE  */
-    TOK_ARRAY_START = 268,         /* TOK_ARRAY_START  */
-    TOK_ARRAY_END = 269,           /* TOK_ARRAY_END  */
-    TOK_LIST_START = 270,          /* TOK_LIST_START  */
-    TOK_LIST_END = 271,            /* TOK_LIST_END  */
-    TOK_COMMA = 272,               /* TOK_COMMA  */
-    TOK_GROUP_START = 273,         /* TOK_GROUP_START  */
-    TOK_GROUP_END = 274,           /* TOK_GROUP_END  */
-    TOK_SEMICOLON = 275,           /* TOK_SEMICOLON  */
-    TOK_GARBAGE = 276,             /* TOK_GARBAGE  */
-    TOK_ERROR = 277                /* TOK_ERROR  */
+    TOK_BIN = 261,                 /* TOK_BIN  */
+    TOK_INTEGER64 = 262,           /* TOK_INTEGER64  */
+    TOK_HEX64 = 263,               /* TOK_HEX64  */
+    TOK_BIN64 = 264,               /* TOK_BIN64  */
+    TOK_FLOAT = 265,               /* TOK_FLOAT  */
+    TOK_STRING = 266,              /* TOK_STRING  */
+    TOK_NAME = 267,                /* TOK_NAME  */
+    TOK_EQUALS = 268,              /* TOK_EQUALS  */
+    TOK_NEWLINE = 269,             /* TOK_NEWLINE  */
+    TOK_ARRAY_START = 270,         /* TOK_ARRAY_START  */
+    TOK_ARRAY_END = 271,           /* TOK_ARRAY_END  */
+    TOK_LIST_START = 272,          /* TOK_LIST_START  */
+    TOK_LIST_END = 273,            /* TOK_LIST_END  */
+    TOK_COMMA = 274,               /* TOK_COMMA  */
+    TOK_GROUP_START = 275,         /* TOK_GROUP_START  */
+    TOK_GROUP_END = 276,           /* TOK_GROUP_END  */
+    TOK_SEMICOLON = 277,           /* TOK_SEMICOLON  */
+    TOK_GARBAGE = 278,             /* TOK_GARBAGE  */
+    TOK_ERROR = 279                /* TOK_ERROR  */
   };
   typedef enum yytokentype yytoken_kind_t;
 #endif
@@ -85,23 +87,25 @@ extern int libconfig_yydebug;
 #define TOK_BOOLEAN 258
 #define TOK_INTEGER 259
 #define TOK_HEX 260
-#define TOK_INTEGER64 261
-#define TOK_HEX64 262
-#define TOK_FLOAT 263
-#define TOK_STRING 264
-#define TOK_NAME 265
-#define TOK_EQUALS 266
-#define TOK_NEWLINE 267
-#define TOK_ARRAY_START 268
-#define TOK_ARRAY_END 269
-#define TOK_LIST_START 270
-#define TOK_LIST_END 271
-#define TOK_COMMA 272
-#define TOK_GROUP_START 273
-#define TOK_GROUP_END 274
-#define TOK_SEMICOLON 275
-#define TOK_GARBAGE 276
-#define TOK_ERROR 277
+#define TOK_BIN 261
+#define TOK_INTEGER64 262
+#define TOK_HEX64 263
+#define TOK_BIN64 264
+#define TOK_FLOAT 265
+#define TOK_STRING 266
+#define TOK_NAME 267
+#define TOK_EQUALS 268
+#define TOK_NEWLINE 269
+#define TOK_ARRAY_START 270
+#define TOK_ARRAY_END 271
+#define TOK_LIST_START 272
+#define TOK_LIST_END 273
+#define TOK_COMMA 274
+#define TOK_GROUP_START 275
+#define TOK_GROUP_END 276
+#define TOK_SEMICOLON 277
+#define TOK_GARBAGE 278
+#define TOK_ERROR 279
 
 /* Value type.  */
 #if ! defined YYSTYPE && ! defined YYSTYPE_IS_DECLARED
@@ -114,7 +118,7 @@ union YYSTYPE
   double fval;
   char *sval;
 
-#line 118 "grammar.h"
+#line 122 "grammar.h"
 
 };
 typedef union YYSTYPE YYSTYPE;
@@ -124,12 +128,6 @@ typedef union YYSTYPE YYSTYPE;
 
 
 
-#if !defined libconfig_yyerror && !defined YYERROR_IS_DECLARED
-void libconfig_yyerror (void *scanner, struct parse_context *ctx, struct scan_context *scan_ctx, const char *msg);
-#endif
-#if !defined libconfig_yylex && !defined YYLEX_IS_DECLARED
-int libconfig_yylex (YYSTYPE *yylvalp, void *scanner);
-#endif
 
 int libconfig_yyparse (void *scanner, struct parse_context *ctx, struct scan_context *scan_ctx);
 

--- a/lib/grammar.h
+++ b/lib/grammar.h
@@ -39,7 +39,7 @@
 # define YY_LIBCONFIG_YY_GRAMMAR_H_INCLUDED
 /* Debug traces.  */
 #ifndef YYDEBUG
-# define YYDEBUG 1
+# define YYDEBUG 0
 #endif
 #if YYDEBUG
 extern int libconfig_yydebug;

--- a/lib/grammar.y
+++ b/lib/grammar.y
@@ -82,8 +82,8 @@ void libconfig_yyerror(void *scanner, struct parse_context *ctx,
   char *sval;
 }
 
-%token <ival> TOK_BOOLEAN TOK_INTEGER TOK_HEX
-%token <llval> TOK_INTEGER64 TOK_HEX64
+%token <ival> TOK_BOOLEAN TOK_INTEGER TOK_HEX TOK_BIN
+%token <llval> TOK_INTEGER64 TOK_HEX64 TOK_BIN64
 %token <fval> TOK_FLOAT
 %token <sval> TOK_STRING TOK_NAME
 %token TOK_EQUALS TOK_NEWLINE TOK_ARRAY_START TOK_ARRAY_END TOK_LIST_START TOK_LIST_END TOK_COMMA TOK_GROUP_START TOK_GROUP_END TOK_SEMICOLON TOK_GARBAGE TOK_ERROR
@@ -296,6 +296,50 @@ simple_value:
     {
       config_setting_set_int64(ctx->setting, $1);
       config_setting_set_format(ctx->setting, CONFIG_FORMAT_HEX);
+    }
+  }
+  | TOK_BIN
+  {
+    if(IN_ARRAY() || IN_LIST())
+    {
+      config_setting_t *e = config_setting_set_int_elem(ctx->parent, -1, $1);
+      if(! e)
+      {
+        libconfig_yyerror(scanner, ctx, scan_ctx, err_array_elem_type);
+        YYABORT;
+      }
+      else
+      {
+        config_setting_set_format(e, CONFIG_FORMAT_BIN);
+        CAPTURE_PARSE_POS(e);
+      }
+    }
+    else
+    {
+      config_setting_set_int(ctx->setting, $1);
+      config_setting_set_format(ctx->setting, CONFIG_FORMAT_BIN);
+    }
+  }
+  | TOK_BIN64
+  {
+    if(IN_ARRAY() || IN_LIST())
+    {
+      config_setting_t *e = config_setting_set_int64_elem(ctx->parent, -1, $1);
+      if(! e)
+      {
+        libconfig_yyerror(scanner, ctx, scan_ctx, err_array_elem_type);
+        YYABORT;
+      }
+      else
+      {
+        config_setting_set_format(e, CONFIG_FORMAT_BIN);
+        CAPTURE_PARSE_POS(e);
+      }
+    }
+    else
+    {
+      config_setting_set_int64(ctx->setting, $1);
+      config_setting_set_format(ctx->setting, CONFIG_FORMAT_BIN);
     }
   }
   | TOK_FLOAT

--- a/lib/libconfig.c
+++ b/lib/libconfig.c
@@ -143,7 +143,8 @@ static void __config_write_value(const config_t *config,
                                  const config_value_t *value, int type,
                                  int format, int depth, FILE *stream)
 {
-  char fbuf[64];
+  char temp_buf[65]; /* Long enough for 64 binary digits + NULL terminator.
+                        Used to be 64 when just used for floats */
 
   switch(type)
   {
@@ -160,7 +161,13 @@ static void __config_write_value(const config_t *config,
           fprintf(stream, "0x%X", value->ival);
           break;
 
-        case CONFIG_FORMAT_DEFAULT:
+        case CONFIG_FORMAT_BIN:
+          /* Once %b/%B become more widely supported, could feature test for them */
+          libconfig_format_bin(value->ival, temp_buf, sizeof(temp_buf));
+          fprintf(stream, "0b%s", temp_buf);
+          break;
+
+       case CONFIG_FORMAT_DEFAULT:
         default:
           fprintf(stream, "%d", value->ival);
           break;
@@ -173,6 +180,12 @@ static void __config_write_value(const config_t *config,
       {
         case CONFIG_FORMAT_HEX:
           fprintf(stream, "0x" INT64_HEX_FMT "L", value->llval);
+          break;
+
+        case CONFIG_FORMAT_BIN:
+          /* Once %b/%B become more widely supported, could feature test for them */
+          libconfig_format_bin(value->llval, temp_buf, sizeof(temp_buf));
+          fprintf(stream, "0b%sL", temp_buf);
           break;
 
         case CONFIG_FORMAT_DEFAULT:
@@ -188,8 +201,8 @@ static void __config_write_value(const config_t *config,
       const int sci_ok = config_get_option(
             config, CONFIG_OPTION_ALLOW_SCIENTIFIC_NOTATION);
       libconfig_format_double(value->fval, config->float_precision, sci_ok,
-                              fbuf, sizeof(fbuf));
-      fputs(fbuf, stream);
+                              temp_buf, sizeof(temp_buf));
+      fputs(temp_buf, stream);
       break;
     }
 
@@ -1181,7 +1194,7 @@ int config_setting_set_format(config_setting_t *setting, unsigned short format)
 {
   if(((setting->type != CONFIG_TYPE_INT)
       && (setting->type != CONFIG_TYPE_INT64))
-     || ((format != CONFIG_FORMAT_DEFAULT) && (format != CONFIG_FORMAT_HEX)))
+     || ((format != CONFIG_FORMAT_DEFAULT) && (format != CONFIG_FORMAT_HEX) && (format != CONFIG_FORMAT_BIN)))
     return(CONFIG_FALSE);
 
   setting->format = format;

--- a/lib/libconfig.h
+++ b/lib/libconfig.h
@@ -57,6 +57,7 @@ extern "C" {
 
 #define CONFIG_FORMAT_DEFAULT  0
 #define CONFIG_FORMAT_HEX      1
+#define CONFIG_FORMAT_BIN      2
 
 #define CONFIG_OPTION_AUTOCONVERT                     0x01
 #define CONFIG_OPTION_SEMICOLON_SEPARATORS            0x02

--- a/lib/scanner.c
+++ b/lib/scanner.c
@@ -1382,7 +1382,7 @@ YY_RULE_SETUP
 #line 144 "scanner.l"
 {
                     int ok;
-                    long long llval = libconfig_parse_integer(yytext, &ok);
+                    long long llval = libconfig_parse_integer(yytext, &ok,0);
                     if(!ok)
                       return(TOK_ERROR);
 
@@ -1401,68 +1401,106 @@ YY_RULE_SETUP
 case 38:
 YY_RULE_SETUP
 #line 161 "scanner.l"
-{ yylval->llval = atoll(yytext); return(TOK_INTEGER64); }
+{
+                    int ok;
+                    long long llval = libconfig_parse_integer(yytext,&ok,1);
+                    if (!ok)
+                      return (TOK_ERROR);
+
+                    yylval->llval = llval;
+                    return(TOK_INTEGER64);
+                  }
 	YY_BREAK
 case 39:
 YY_RULE_SETUP
-#line 162 "scanner.l"
+#line 170 "scanner.l"
 {
-                    yylval->ival = strtoul(yytext+2, NULL,2);
-                    return(TOK_BIN);
+                    int ok;
+                    unsigned long long llval = libconfig_parse_bin64(yytext,&ok,0);
+                    if (!ok)
+                      return (TOK_ERROR);
+
+                    if (llval < INT_MAX)
+                    {
+                      yylval->ival = (int) llval;
+                      return TOK_BIN;
+                    }
+
+                    yylval->llval = llval;
+                    return(TOK_BIN64);
                   }
 	YY_BREAK
 case 40:
 YY_RULE_SETUP
-#line 166 "scanner.l"
+#line 185 "scanner.l"
 {
-                    yylval->llval = libconfig_parse_bin64(yytext);
-                    return(TOK_BIN64);
+                    int ok;
+                    unsigned long long llval = libconfig_parse_bin64(yytext,&ok,1);
+                    if (!ok)
+                      return (TOK_ERROR);
+                    yylval->llval = llval;
+                    return (TOK_BIN64);
                   }
 	YY_BREAK
 case 41:
 YY_RULE_SETUP
-#line 170 "scanner.l"
+#line 193 "scanner.l"
 {
-                    yylval->ival = strtoul(yytext, NULL, 16);
-                    return(TOK_HEX);
+                    int ok;
+                    unsigned long long llval = libconfig_parse_hex64(yytext,&ok,0);
+                    if (!ok)
+                      return (TOK_ERROR);
+
+                    if (llval < INT_MAX)
+                    {
+                      yylval->ival = (int) llval;
+                      return TOK_HEX;
+                    }
+
+                    yylval->llval = llval;
+                    return(TOK_HEX64);
                   }
 	YY_BREAK
 case 42:
 YY_RULE_SETUP
-#line 174 "scanner.l"
+#line 208 "scanner.l"
 {
-                    yylval->llval = libconfig_parse_hex64(yytext);
-                    return(TOK_HEX64);
+                    int ok;
+                    unsigned long long llval = libconfig_parse_hex64(yytext,&ok,1);
+                    if (!ok)
+                      return (TOK_ERROR);
+                    yylval->llval = llval;
+                    return (TOK_HEX64);
                   }
 	YY_BREAK
 case 43:
 YY_RULE_SETUP
-#line 178 "scanner.l"
+#line 216 "scanner.l"
 { return(TOK_ARRAY_START); }
 	YY_BREAK
 case 44:
 YY_RULE_SETUP
-#line 179 "scanner.l"
+#line 217 "scanner.l"
 { return(TOK_ARRAY_END); }
 	YY_BREAK
 case 45:
 YY_RULE_SETUP
-#line 180 "scanner.l"
+#line 218 "scanner.l"
 { return(TOK_LIST_START); }
 	YY_BREAK
 case 46:
 YY_RULE_SETUP
-#line 181 "scanner.l"
+#line 219 "scanner.l"
 { return(TOK_LIST_END); }
 	YY_BREAK
 case 47:
 YY_RULE_SETUP
-#line 182 "scanner.l"
+#line 220 "scanner.l"
 { return(TOK_SEMICOLON); }
 	YY_BREAK
 case 48:
 YY_RULE_SETUP
-#line 183 "scanner.l"
+#line 221 "scanner.l"
 { return(TOK_GARBAGE); }
 	YY_BREAK
 case YY_STATE_EOF(INITIAL):
@@ -1470,7 +1508,7 @@ case YY_STATE_EOF(SINGLE_LINE_COMMENT):
 case YY_STATE_EOF(MULTI_LINE_COMMENT):
 case YY_STATE_EOF(STRING):
 case YY_STATE_EOF(INCLUDE):
-#line 185 "scanner.l"
+#line 223 "scanner.l"
 {
   const char *error = NULL;
   FILE *fp;
@@ -1506,10 +1544,10 @@ case YY_STATE_EOF(INCLUDE):
 	YY_BREAK
 case 49:
 YY_RULE_SETUP
-#line 218 "scanner.l"
+#line 256 "scanner.l"
 ECHO;
 	YY_BREAK
-#line 1512 "scanner.c"
+#line 1550 "scanner.c"
 
 	case YY_END_OF_BUFFER:
 		{
@@ -2638,7 +2676,7 @@ void yyfree (void * ptr , yyscan_t yyscanner)
 
 #define YYTABLES_NAME "yytables"
 
-#line 218 "scanner.l"
+#line 256 "scanner.l"
 
 
 void *libconfig_yyalloc(size_t bytes, void *yyscanner)

--- a/lib/scanner.c
+++ b/lib/scanner.c
@@ -580,8 +580,8 @@ static void yynoreturn yy_fatal_error ( const char* msg , yyscan_t yyscanner );
 	yyg->yy_hold_char = *yy_cp; \
 	*yy_cp = '\0'; \
 	yyg->yy_c_buf_p = yy_cp;
-#define YY_NUM_RULES 44
-#define YY_END_OF_BUFFER 45
+#define YY_NUM_RULES 49
+#define YY_END_OF_BUFFER 50
 /* This struct is not used in this scanner,
    but its presence is necessary. */
 struct yy_trans_info
@@ -589,38 +589,39 @@ struct yy_trans_info
 	flex_int32_t yy_verify;
 	flex_int32_t yy_nxt;
 	};
-static const flex_int16_t yy_accept[105] =
+static const flex_int16_t yy_accept[112] =
     {   0,
         0,    0,    0,    0,    0,    0,    0,    0,    0,    0,
-       45,   43,   25,   24,   24,    8,    1,   40,   41,   32,
-       43,   27,   33,   43,   34,   34,   26,   42,   32,   32,
-       38,   39,   28,   29,   25,   43,    3,    2,    6,    7,
-        6,    9,   18,   17,   20,   23,   44,   25,   32,   33,
-       34,   33,    0,    4,    1,   33,    0,   35,    0,   32,
-       32,   25,    0,    0,    5,    9,   15,    0,   14,   13,
-       10,   11,   12,   20,   22,   21,    0,   33,   33,    0,
-        0,   33,   35,   36,   32,   32,    0,    0,    0,   33,
-       37,   32,   30,    0,   16,   37,   31,    0,    0,    0,
+       50,   48,   27,   28,   27,    8,    1,   45,   46,   35,
+       48,   30,   36,   48,   37,   37,   29,   47,   35,   35,
+       43,   44,   31,   32,   28,   48,    3,    2,    6,    7,
+        6,    9,   21,   20,   23,   26,   49,   28,   35,   36,
+       37,   36,    0,    4,    1,   36,    0,    0,   38,    0,
+       35,   35,   28,    0,    0,    5,    9,   18,    0,   17,
+       10,   11,   16,   12,   13,   14,   15,   23,   25,   24,
+        0,   36,   36,    0,   39,    0,   36,   38,   41,   35,
+       35,    0,    0,    0,   36,   40,   42,   35,   33,    0,
 
-        0,    0,   19,    0
+       19,   40,   42,   34,    0,    0,    0,    0,    0,   22,
+        0
     } ;
 
 static const YY_CHAR yy_ec[256] =
     {   0,
-        1,    1,    1,    1,    1,    1,    1,    1,    2,    3,
-        1,    4,    5,    1,    1,    1,    1,    1,    1,    1,
+        1,    1,    1,    1,    1,    1,    2,    3,    4,    5,
+        6,    7,    8,    1,    1,    1,    1,    1,    1,    1,
         1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
-        1,    2,    1,    6,    7,    1,    1,    1,    1,    8,
-        9,   10,   11,   12,   13,   14,   15,   16,   17,   17,
-       17,   17,   17,   17,   17,   17,   17,   18,   19,    1,
-       20,    1,    1,   21,   22,   23,   23,   23,   24,   25,
-       26,   26,   26,   26,   26,   27,   26,   26,   26,   26,
-       26,   28,   29,   30,   31,   26,   26,   32,   26,   26,
-       33,   34,   35,    1,   36,    1,   22,   23,   37,   38,
+        1,    4,    1,    9,   10,    1,    1,    1,    1,   11,
+       12,   13,   14,   15,   16,   17,   18,   19,   20,   21,
+       21,   21,   21,   21,   21,   21,   21,   22,   23,    1,
+       24,    1,    1,   25,   26,   27,   28,   28,   29,   30,
+       31,   31,   31,   31,   31,   32,   31,   31,   31,   31,
+       31,   33,   34,   35,   36,   31,   31,   37,   31,   31,
+       38,   39,   40,    1,   41,    1,   42,   43,   44,   45,
 
-       39,   40,   26,   26,   41,   26,   26,   42,   26,   43,
-       26,   26,   26,   44,   29,   45,   46,   26,   26,   32,
-       26,   26,   47,    1,   48,    1,    1,    1,    1,    1,
+       46,   47,   31,   31,   48,   31,   31,   49,   31,   50,
+       31,   31,   31,   51,   34,   52,   53,   54,   31,   37,
+       31,   31,   55,    1,   56,    1,    1,    1,    1,    1,
         1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
         1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
         1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
@@ -637,119 +638,132 @@ static const YY_CHAR yy_ec[256] =
         1,    1,    1,    1,    1
     } ;
 
-static const YY_CHAR yy_meta[49] =
+static const YY_CHAR yy_meta[57] =
     {   0,
-        1,    1,    1,    1,    1,    2,    1,    1,    1,    3,
-        1,    1,    3,    1,    1,    4,    4,    1,    1,    1,
-        1,    4,    4,    4,    4,    3,    3,    3,    3,    3,
-        3,    3,    1,    2,    1,    3,    4,    4,    4,    4,
-        3,    3,    3,    3,    3,    3,    1,    1
+        1,    1,    1,    1,    1,    1,    1,    1,    2,    1,
+        1,    1,    3,    1,    1,    3,    1,    1,    4,    4,
+        4,    1,    1,    1,    1,    4,    4,    4,    4,    4,
+        3,    3,    3,    3,    3,    3,    3,    1,    2,    1,
+        3,    4,    4,    4,    4,    4,    4,    3,    3,    3,
+        3,    3,    3,    3,    1,    1
     } ;
 
-static const flex_int16_t yy_base[115] =
+static const flex_int16_t yy_base[122] =
     {   0,
-        0,   47,  199,  198,   47,   48,   46,   47,   48,   49,
-      200,  203,  197,  203,  203,  203,  203,  203,  203,    0,
-       45,  203,   47,   50,   60,   74,  203,  203,  176,   28,
-      203,  203,  203,  203,   64,  156,  203,  203,  203,  203,
-      181,    0,  203,   63,    0,  203,   83,  191,    0,   88,
-      102,   98,   62,  203,  203,  104,  119,  162,    0,   67,
-       65,  121,  127,  124,  203,    0,  203,    0,  203,  203,
-      203,  203,  203,    0,  203,  203,  108,  117,  122,  134,
-      132,  136,  203,  139,  136,  116,  126,    0,  140,  142,
-      135,  130,    0,  102,  203,  203,    0,   85,   72,   63,
+        0,   53,  235,  234,   53,   54,   51,   52,   53,   54,
+      238,  241,  241,  233,  241,  241,  241,  241,  241,    0,
+       51,  241,   54,   51,   84,   77,  241,  241,   39,   44,
+      241,  241,  241,  241,   82,  186,  241,  241,  241,  241,
+      212,    0,  241,  122,    0,  241,   71,  205,    0,   99,
+      105,  120,   68,  241,  241,  133,   95,  161,  176,    0,
+       53,   76,  113,  158,  142,  241,    0,  241,    0,  241,
+      241,  241,  241,  241,  241,  241,  241,    0,  241,  241,
+      123,  127,  164,  175,  136,  167,  178,  241,  146,  137,
+      104,  126,    0,  181,  184,  135,  128,  161,    0,  108,
 
-       98,  158,  203,  203,  169,  173,  177,  181,  183,  187,
-      191,   89,   66,   63
+      241,  241,  241,    0,   83,   90,   86,  104,  154,  241,
+      241,  210,  214,  218,  222,  224,  228,  232,   95,   75,
+       72
     } ;
 
-static const flex_int16_t yy_def[115] =
+static const flex_int16_t yy_def[122] =
     {   0,
-      104,    1,  105,  105,  106,  106,  107,  107,  108,  108,
-      104,  104,  104,  104,  104,  104,  104,  104,  104,  109,
-      104,  104,  104,  104,  104,  104,  104,  104,  109,  109,
-      104,  104,  104,  104,  104,  104,  104,  104,  104,  104,
-      104,  110,  104,  104,  111,  104,  104,  104,  109,  104,
-      104,  104,  104,  104,  104,  104,  104,  104,  112,  109,
-      109,  104,  104,  104,  104,  110,  104,  113,  104,  104,
-      104,  104,  104,  111,  104,  104,  104,  104,  104,  104,
-      104,  104,  104,  112,  109,  109,  104,  114,  104,  104,
-      104,  109,  109,  104,  104,  104,  109,  104,  104,  104,
+      111,    1,  112,  112,  113,  113,  114,  114,  115,  115,
+      111,  111,  111,  111,  111,  111,  111,  111,  111,  116,
+      111,  111,  111,  111,  111,  111,  111,  111,  116,  116,
+      111,  111,  111,  111,  111,  111,  111,  111,  111,  111,
+      111,  117,  111,  111,  118,  111,  111,  111,  116,  111,
+      111,  111,  111,  111,  111,  111,  111,  111,  111,  119,
+      116,  116,  111,  111,  111,  111,  117,  111,  120,  111,
+      111,  111,  111,  111,  111,  111,  111,  118,  111,  111,
+      111,  111,  111,  111,  111,  111,  111,  111,  119,  116,
+      116,  111,  121,  111,  111,  111,  111,  116,  116,  111,
 
-      104,  104,  104,    0,  104,  104,  104,  104,  104,  104,
-      104,  104,  104,  104
+      111,  111,  111,  116,  111,  111,  111,  111,  111,  111,
+        0,  111,  111,  111,  111,  111,  111,  111,  111,  111,
+      111
     } ;
 
-static const flex_int16_t yy_nxt[252] =
+static const flex_int16_t yy_nxt[298] =
     {   0,
-       12,   13,   14,   15,   15,   16,   17,   18,   19,   20,
-       21,   22,   21,   23,   24,   25,   26,   27,   28,   27,
-       12,   20,   20,   20,   29,   20,   20,   20,   20,   30,
-       20,   20,   31,   12,   32,   12,   20,   20,   20,   29,
-       20,   20,   20,   20,   30,   20,   33,   34,   35,   40,
-       40,   43,   43,   46,   46,   61,   41,   41,   50,   54,
-       51,   51,   52,   52,   55,   62,   95,   36,   67,   88,
-       53,   61,   77,   56,   77,   51,   51,   78,   78,   44,
-       44,   47,   47,   57,   63,   53,   58,   56,   75,   51,
-       51,   59,   84,   85,   68,   86,   69,   57,   57,  102,
+       12,   13,   13,   14,   15,   13,   13,   13,   16,   17,
+       18,   19,   20,   21,   22,   21,   23,   24,   25,   26,
+       26,   27,   28,   27,   12,   20,   20,   20,   20,   29,
+       20,   20,   20,   20,   30,   20,   20,   31,   12,   32,
+       12,   20,   20,   20,   20,   20,   29,   20,   20,   20,
+       20,   30,   20,   20,   33,   34,   35,   40,   40,   43,
+       43,   46,   46,   54,   61,   41,   41,   50,   55,   51,
+       51,   51,   52,   52,   52,  101,   62,   36,   93,   79,
+       61,   81,   53,   81,   90,   63,   82,   82,   82,   44,
+       44,   47,   47,   56,   62,   51,   51,   51,   89,   53,
 
-       58,  101,   70,   52,   52,   71,   72,   73,   85,  100,
-       86,   53,   57,   52,   52,   56,   76,   51,   51,   79,
-       79,   53,   62,   78,   78,   57,   53,   80,   58,   81,
-       99,   81,   78,   78,   82,   82,   53,   79,   79,   93,
-       57,   63,   80,   98,   89,   80,   89,   82,   82,   90,
-       90,   82,   82,   97,   93,   90,   90,   90,   90,  102,
-       80,   96,   94,  103,   92,   91,   87,   64,   97,   37,
-       37,   37,   37,   39,   39,   39,   39,   42,   42,   42,
-       42,   45,   45,   45,   45,   49,   49,   66,   83,   66,
-       66,   74,   48,   74,   74,   65,   64,   60,   48,  104,
+       56,   90,   51,   51,   51,   58,   64,  109,   59,   80,
+       57,   91,   58,   85,   85,   59,   63,   52,   52,   52,
+       60,   56,   58,   51,   51,   51,   57,   53,   91,   58,
+       68,  108,   99,   58,  107,  106,   59,   64,   52,   52,
+       52,   82,   82,   82,   53,   82,   82,   82,   53,   99,
+       58,   83,   83,   83,   85,   85,  105,  109,   69,  103,
+       70,   84,  110,   71,   72,   53,  102,   96,   73,  100,
+       98,   74,   75,   76,   86,   77,   86,   97,   84,   87,
+       87,   87,   83,   83,   83,   87,   87,   87,   94,  104,
+       94,   92,   84,   95,   95,   95,   87,   87,   87,   95,
 
-       38,   38,   11,  104,  104,  104,  104,  104,  104,  104,
-      104,  104,  104,  104,  104,  104,  104,  104,  104,  104,
-      104,  104,  104,  104,  104,  104,  104,  104,  104,  104,
-      104,  104,  104,  104,  104,  104,  104,  104,  104,  104,
-      104,  104,  104,  104,  104,  104,  104,  104,  104,  104,
-      104
+       95,   95,   95,   95,   95,   65,  104,   88,   48,   84,
+       37,   37,   37,   37,   39,   39,   39,   39,   42,   42,
+       42,   42,   45,   45,   45,   45,   49,   49,   67,   66,
+       67,   67,   78,   65,   78,   78,   48,  111,   38,   38,
+       11,  111,  111,  111,  111,  111,  111,  111,  111,  111,
+      111,  111,  111,  111,  111,  111,  111,  111,  111,  111,
+      111,  111,  111,  111,  111,  111,  111,  111,  111,  111,
+      111,  111,  111,  111,  111,  111,  111,  111,  111,  111,
+      111,  111,  111,  111,  111,  111,  111,  111,  111,  111,
+      111,  111,  111,  111,  111,  111,  111
+
     } ;
 
-static const flex_int16_t yy_chk[252] =
+static const flex_int16_t yy_chk[298] =
     {   0,
         1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
         1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
         1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
         1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
-        1,    1,    1,    1,    1,    1,    1,    1,    2,    5,
-        6,    7,    8,    9,   10,   30,    5,    6,   21,   24,
-       21,   21,   23,   23,   24,   35,  114,    2,   44,  113,
-       23,   30,   53,   25,   53,   25,   25,   53,   53,    7,
-        8,    9,   10,   25,   35,   23,   25,   26,   47,   26,
-       26,   25,  112,   60,   44,   61,   44,   26,   25,  101,
+        1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
+        1,    1,    1,    1,    1,    1,    2,    5,    6,    7,
+        8,    9,   10,   24,   29,    5,    6,   21,   24,   21,
+       21,   21,   23,   23,   23,  121,   30,    2,  120,   47,
+       29,   53,   23,   53,   61,   35,   53,   53,   53,    7,
+        8,    9,   10,   26,   30,   26,   26,   26,  119,   23,
 
-       26,  100,   44,   50,   50,   44,   44,   44,   60,   99,
-       61,   50,   26,   52,   52,   51,   47,   51,   51,   56,
-       56,   52,   62,   77,   77,   51,   50,   56,   51,   57,
-       98,   57,   78,   78,   57,   57,   52,   79,   79,   86,
-       51,   62,   56,   94,   80,   79,   80,   81,   81,   80,
-       80,   82,   82,   92,   86,   89,   89,   90,   90,  102,
-       79,   91,   87,  102,   85,   84,   64,   63,   92,  105,
-      105,  105,  105,  106,  106,  106,  106,  107,  107,  107,
-      107,  108,  108,  108,  108,  109,  109,  110,   58,  110,
-      110,  111,   48,  111,  111,   41,   36,   29,   13,   11,
+       25,   61,   25,   25,   25,   26,   35,  108,   26,   47,
+       25,   62,   25,   57,   57,   25,   63,   50,   50,   50,
+       25,   51,   26,   51,   51,   51,   25,   50,   62,   25,
+       44,  107,   91,   51,  106,  105,   51,   63,   52,   52,
+       52,   81,   81,   81,   50,   82,   82,   82,   52,   91,
+       51,   56,   56,   56,   85,   85,  100,  109,   44,   97,
+       44,   56,  109,   44,   44,   52,   96,   85,   44,   92,
+       90,   44,   44,   44,   58,   44,   58,   89,   56,   58,
+       58,   58,   83,   83,   83,   86,   86,   86,   84,   98,
+       84,   65,   83,   84,   84,   84,   87,   87,   87,   94,
 
-        4,    3,  104,  104,  104,  104,  104,  104,  104,  104,
-      104,  104,  104,  104,  104,  104,  104,  104,  104,  104,
-      104,  104,  104,  104,  104,  104,  104,  104,  104,  104,
-      104,  104,  104,  104,  104,  104,  104,  104,  104,  104,
-      104,  104,  104,  104,  104,  104,  104,  104,  104,  104,
-      104
+       94,   94,   95,   95,   95,   64,   98,   59,   48,   83,
+      112,  112,  112,  112,  113,  113,  113,  113,  114,  114,
+      114,  114,  115,  115,  115,  115,  116,  116,  117,   41,
+      117,  117,  118,   36,  118,  118,   14,   11,    4,    3,
+      111,  111,  111,  111,  111,  111,  111,  111,  111,  111,
+      111,  111,  111,  111,  111,  111,  111,  111,  111,  111,
+      111,  111,  111,  111,  111,  111,  111,  111,  111,  111,
+      111,  111,  111,  111,  111,  111,  111,  111,  111,  111,
+      111,  111,  111,  111,  111,  111,  111,  111,  111,  111,
+      111,  111,  111,  111,  111,  111,  111
+
     } ;
 
 /* Table of booleans, true if rule could match eol. */
-static const flex_int32_t yy_rule_can_match_eol[45] =
+static const flex_int32_t yy_rule_can_match_eol[50] =
     {   0,
 0, 1, 0, 0, 0, 0, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
-    1, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
-    0, 0, 0, 0, 0,     };
+    0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0,     };
 
 /* The intent behind this definition is that it'll catch
  * any uses of REJECT which flex missed.
@@ -802,9 +816,9 @@ static const flex_int32_t yy_rule_can_match_eol[45] =
 
 #define YY_NO_INPUT // Suppress generation of useless input() function
 
-#line 805 "scanner.c"
+#line 819 "scanner.c"
 
-#line 807 "scanner.c"
+#line 821 "scanner.c"
 
 #define INITIAL 0
 #define SINGLE_LINE_COMMENT 1
@@ -1081,10 +1095,10 @@ YY_DECL
 		}
 
 	{
-#line 71 "scanner.l"
+#line 73 "scanner.l"
 
 
-#line 1087 "scanner.c"
+#line 1101 "scanner.c"
 
 	while ( /*CONSTCOND*/1 )		/* loops until end-of-file is reached */
 		{
@@ -1112,13 +1126,13 @@ yy_match:
 			while ( yy_chk[yy_base[yy_current_state] + yy_c] != yy_current_state )
 				{
 				yy_current_state = (int) yy_def[yy_current_state];
-				if ( yy_current_state >= 105 )
+				if ( yy_current_state >= 112 )
 					yy_c = yy_meta[yy_c];
 				}
 			yy_current_state = yy_nxt[yy_base[yy_current_state] + yy_c];
 			++yy_cp;
 			}
-		while ( yy_current_state != 104 );
+		while ( yy_current_state != 111 );
 		yy_cp = yyg->yy_last_accepting_cpos;
 		yy_current_state = yyg->yy_last_accepting_state;
 
@@ -1152,128 +1166,143 @@ do_action:	/* This label is used only to access EOF actions. */
 
 case 1:
 YY_RULE_SETUP
-#line 73 "scanner.l"
+#line 75 "scanner.l"
 { BEGIN SINGLE_LINE_COMMENT; }
 	YY_BREAK
 case 2:
 /* rule 2 can match eol */
 YY_RULE_SETUP
-#line 74 "scanner.l"
+#line 76 "scanner.l"
 { BEGIN INITIAL; }
 	YY_BREAK
 case 3:
 YY_RULE_SETUP
-#line 75 "scanner.l"
+#line 77 "scanner.l"
 { /* ignore */ }
 	YY_BREAK
 case 4:
 YY_RULE_SETUP
-#line 77 "scanner.l"
+#line 79 "scanner.l"
 { BEGIN MULTI_LINE_COMMENT; }
 	YY_BREAK
 case 5:
 YY_RULE_SETUP
-#line 78 "scanner.l"
+#line 80 "scanner.l"
 { BEGIN INITIAL; }
 	YY_BREAK
 case 6:
 YY_RULE_SETUP
-#line 79 "scanner.l"
+#line 81 "scanner.l"
 { /* ignore */ }
 	YY_BREAK
 case 7:
 /* rule 7 can match eol */
 YY_RULE_SETUP
-#line 80 "scanner.l"
+#line 82 "scanner.l"
 { /* ignore */ }
 	YY_BREAK
 case 8:
 YY_RULE_SETUP
-#line 82 "scanner.l"
+#line 84 "scanner.l"
 { BEGIN STRING; }
 	YY_BREAK
 case 9:
 /* rule 9 can match eol */
 YY_RULE_SETUP
-#line 83 "scanner.l"
+#line 85 "scanner.l"
 { libconfig_scanctx_append_string(yyextra, yytext); }
 	YY_BREAK
 case 10:
 YY_RULE_SETUP
-#line 84 "scanner.l"
-{ libconfig_scanctx_append_char(yyextra, '\n'); }
+#line 86 "scanner.l"
+{ libconfig_scanctx_append_char(yyextra, '\a'); }
 	YY_BREAK
 case 11:
 YY_RULE_SETUP
-#line 85 "scanner.l"
-{ libconfig_scanctx_append_char(yyextra, '\r'); }
+#line 87 "scanner.l"
+{ libconfig_scanctx_append_char(yyextra, '\b'); }
 	YY_BREAK
 case 12:
 YY_RULE_SETUP
-#line 86 "scanner.l"
-{ libconfig_scanctx_append_char(yyextra, '\t'); }
+#line 88 "scanner.l"
+{ libconfig_scanctx_append_char(yyextra, '\n'); }
 	YY_BREAK
 case 13:
 YY_RULE_SETUP
-#line 87 "scanner.l"
-{ libconfig_scanctx_append_char(yyextra, '\f'); }
+#line 89 "scanner.l"
+{ libconfig_scanctx_append_char(yyextra, '\r'); }
 	YY_BREAK
 case 14:
 YY_RULE_SETUP
-#line 88 "scanner.l"
-{ libconfig_scanctx_append_char(yyextra, '\\'); }
+#line 90 "scanner.l"
+{ libconfig_scanctx_append_char(yyextra, '\t'); }
 	YY_BREAK
 case 15:
 YY_RULE_SETUP
-#line 89 "scanner.l"
-{ libconfig_scanctx_append_char(yyextra, '\"'); }
+#line 91 "scanner.l"
+{ libconfig_scanctx_append_char(yyextra, '\v'); }
 	YY_BREAK
 case 16:
 YY_RULE_SETUP
-#line 90 "scanner.l"
+#line 92 "scanner.l"
+{ libconfig_scanctx_append_char(yyextra, '\f'); }
+	YY_BREAK
+case 17:
+YY_RULE_SETUP
+#line 93 "scanner.l"
+{ libconfig_scanctx_append_char(yyextra, '\\'); }
+	YY_BREAK
+case 18:
+YY_RULE_SETUP
+#line 94 "scanner.l"
+{ libconfig_scanctx_append_char(yyextra, '\"'); }
+	YY_BREAK
+case 19:
+YY_RULE_SETUP
+#line 95 "scanner.l"
 {
                     char c = (char)(strtol(yytext + 2, NULL, 16) & 0xFF);
                     libconfig_scanctx_append_char(yyextra, c);
                   }
 	YY_BREAK
-case 17:
+case 20:
 YY_RULE_SETUP
-#line 94 "scanner.l"
+#line 99 "scanner.l"
 { libconfig_scanctx_append_char(yyextra, '\\'); }
 	YY_BREAK
-case 18:
+case 21:
 YY_RULE_SETUP
-#line 95 "scanner.l"
+#line 100 "scanner.l"
 {
                     yylval->sval = libconfig_scanctx_take_string(yyextra);
                     BEGIN INITIAL;
                     return(TOK_STRING);
                   }
 	YY_BREAK
-case 19:
-YY_RULE_SETUP
-#line 101 "scanner.l"
-{ BEGIN INCLUDE; }
-	YY_BREAK
-case 20:
-/* rule 20 can match eol */
-YY_RULE_SETUP
-#line 102 "scanner.l"
-{ libconfig_scanctx_append_string(yyextra, yytext); }
-	YY_BREAK
-case 21:
-YY_RULE_SETUP
-#line 103 "scanner.l"
-{ libconfig_scanctx_append_char(yyextra, '\\'); }
-	YY_BREAK
 case 22:
 YY_RULE_SETUP
-#line 104 "scanner.l"
-{ libconfig_scanctx_append_char(yyextra, '\"'); }
+#line 106 "scanner.l"
+{ BEGIN INCLUDE; }
 	YY_BREAK
 case 23:
+/* rule 23 can match eol */
 YY_RULE_SETUP
-#line 105 "scanner.l"
+#line 107 "scanner.l"
+{ libconfig_scanctx_append_string(yyextra, yytext); }
+	YY_BREAK
+case 24:
+YY_RULE_SETUP
+#line 108 "scanner.l"
+{ libconfig_scanctx_append_char(yyextra, '\\'); }
+	YY_BREAK
+case 25:
+YY_RULE_SETUP
+#line 109 "scanner.l"
+{ libconfig_scanctx_append_char(yyextra, '\"'); }
+	YY_BREAK
+case 26:
+YY_RULE_SETUP
+#line 110 "scanner.l"
 {
   const char *error = NULL;
   const char *path = libconfig_scanctx_take_string(yyextra);
@@ -1297,60 +1326,60 @@ YY_RULE_SETUP
   BEGIN INITIAL;
 }
 	YY_BREAK
-case 24:
-/* rule 24 can match eol */
-YY_RULE_SETUP
-#line 128 "scanner.l"
-{ /* ignore */ }
-	YY_BREAK
-case 25:
-YY_RULE_SETUP
-#line 129 "scanner.l"
-{ /* ignore */ }
-	YY_BREAK
-case 26:
-YY_RULE_SETUP
-#line 131 "scanner.l"
-{ return(TOK_EQUALS); }
-	YY_BREAK
 case 27:
+/* rule 27 can match eol */
 YY_RULE_SETUP
-#line 132 "scanner.l"
-{ return(TOK_COMMA); }
+#line 133 "scanner.l"
+{ /* ignore */ }
 	YY_BREAK
 case 28:
 YY_RULE_SETUP
-#line 133 "scanner.l"
-{ return(TOK_GROUP_START); }
+#line 134 "scanner.l"
+{ /* ignore */ }
 	YY_BREAK
 case 29:
 YY_RULE_SETUP
-#line 134 "scanner.l"
-{ return(TOK_GROUP_END); }
+#line 136 "scanner.l"
+{ return(TOK_EQUALS); }
 	YY_BREAK
 case 30:
 YY_RULE_SETUP
-#line 135 "scanner.l"
-{ yylval->ival = 1; return(TOK_BOOLEAN); }
+#line 137 "scanner.l"
+{ return(TOK_COMMA); }
 	YY_BREAK
 case 31:
 YY_RULE_SETUP
-#line 136 "scanner.l"
-{ yylval->ival = 0; return(TOK_BOOLEAN); }
+#line 138 "scanner.l"
+{ return(TOK_GROUP_START); }
 	YY_BREAK
 case 32:
 YY_RULE_SETUP
-#line 137 "scanner.l"
-{ yylval->sval = yytext; return(TOK_NAME); }
+#line 139 "scanner.l"
+{ return(TOK_GROUP_END); }
 	YY_BREAK
 case 33:
 YY_RULE_SETUP
-#line 138 "scanner.l"
-{ yylval->fval = atof(yytext); return(TOK_FLOAT); }
+#line 140 "scanner.l"
+{ yylval->ival = 1; return(TOK_BOOLEAN); }
 	YY_BREAK
 case 34:
 YY_RULE_SETUP
-#line 139 "scanner.l"
+#line 141 "scanner.l"
+{ yylval->ival = 0; return(TOK_BOOLEAN); }
+	YY_BREAK
+case 35:
+YY_RULE_SETUP
+#line 142 "scanner.l"
+{ yylval->sval = yytext; return(TOK_NAME); }
+	YY_BREAK
+case 36:
+YY_RULE_SETUP
+#line 143 "scanner.l"
+{ yylval->fval = atof(yytext); return(TOK_FLOAT); }
+	YY_BREAK
+case 37:
+YY_RULE_SETUP
+#line 144 "scanner.l"
 {
                     int ok;
                     long long llval = libconfig_parse_integer(yytext, &ok);
@@ -1369,55 +1398,71 @@ YY_RULE_SETUP
                     }
                   }
 	YY_BREAK
-case 35:
+case 38:
 YY_RULE_SETUP
-#line 156 "scanner.l"
+#line 161 "scanner.l"
 { yylval->llval = atoll(yytext); return(TOK_INTEGER64); }
 	YY_BREAK
-case 36:
+case 39:
 YY_RULE_SETUP
-#line 157 "scanner.l"
+#line 162 "scanner.l"
+{
+                    yylval->ival = strtoul(yytext+2, NULL,2);
+                    return(TOK_BIN);
+                  }
+	YY_BREAK
+case 40:
+YY_RULE_SETUP
+#line 166 "scanner.l"
+{
+                    yylval->llval = libconfig_parse_bin64(yytext);
+                    return(TOK_BIN64);
+                  }
+	YY_BREAK
+case 41:
+YY_RULE_SETUP
+#line 170 "scanner.l"
 {
                     yylval->ival = strtoul(yytext, NULL, 16);
                     return(TOK_HEX);
                   }
 	YY_BREAK
-case 37:
+case 42:
 YY_RULE_SETUP
-#line 161 "scanner.l"
+#line 174 "scanner.l"
 {
                     yylval->llval = libconfig_parse_hex64(yytext);
                     return(TOK_HEX64);
                   }
 	YY_BREAK
-case 38:
-YY_RULE_SETUP
-#line 165 "scanner.l"
-{ return(TOK_ARRAY_START); }
-	YY_BREAK
-case 39:
-YY_RULE_SETUP
-#line 166 "scanner.l"
-{ return(TOK_ARRAY_END); }
-	YY_BREAK
-case 40:
-YY_RULE_SETUP
-#line 167 "scanner.l"
-{ return(TOK_LIST_START); }
-	YY_BREAK
-case 41:
-YY_RULE_SETUP
-#line 168 "scanner.l"
-{ return(TOK_LIST_END); }
-	YY_BREAK
-case 42:
-YY_RULE_SETUP
-#line 169 "scanner.l"
-{ return(TOK_SEMICOLON); }
-	YY_BREAK
 case 43:
 YY_RULE_SETUP
-#line 170 "scanner.l"
+#line 178 "scanner.l"
+{ return(TOK_ARRAY_START); }
+	YY_BREAK
+case 44:
+YY_RULE_SETUP
+#line 179 "scanner.l"
+{ return(TOK_ARRAY_END); }
+	YY_BREAK
+case 45:
+YY_RULE_SETUP
+#line 180 "scanner.l"
+{ return(TOK_LIST_START); }
+	YY_BREAK
+case 46:
+YY_RULE_SETUP
+#line 181 "scanner.l"
+{ return(TOK_LIST_END); }
+	YY_BREAK
+case 47:
+YY_RULE_SETUP
+#line 182 "scanner.l"
+{ return(TOK_SEMICOLON); }
+	YY_BREAK
+case 48:
+YY_RULE_SETUP
+#line 183 "scanner.l"
 { return(TOK_GARBAGE); }
 	YY_BREAK
 case YY_STATE_EOF(INITIAL):
@@ -1425,7 +1470,7 @@ case YY_STATE_EOF(SINGLE_LINE_COMMENT):
 case YY_STATE_EOF(MULTI_LINE_COMMENT):
 case YY_STATE_EOF(STRING):
 case YY_STATE_EOF(INCLUDE):
-#line 172 "scanner.l"
+#line 185 "scanner.l"
 {
   const char *error = NULL;
   FILE *fp;
@@ -1459,12 +1504,12 @@ case YY_STATE_EOF(INCLUDE):
   }
 }
 	YY_BREAK
-case 44:
+case 49:
 YY_RULE_SETUP
-#line 205 "scanner.l"
+#line 218 "scanner.l"
 ECHO;
 	YY_BREAK
-#line 1467 "scanner.c"
+#line 1512 "scanner.c"
 
 	case YY_END_OF_BUFFER:
 		{
@@ -1763,7 +1808,7 @@ static int yy_get_next_buffer (yyscan_t yyscanner)
 		while ( yy_chk[yy_base[yy_current_state] + yy_c] != yy_current_state )
 			{
 			yy_current_state = (int) yy_def[yy_current_state];
-			if ( yy_current_state >= 105 )
+			if ( yy_current_state >= 112 )
 				yy_c = yy_meta[yy_c];
 			}
 		yy_current_state = yy_nxt[yy_base[yy_current_state] + yy_c];
@@ -1792,11 +1837,11 @@ static int yy_get_next_buffer (yyscan_t yyscanner)
 	while ( yy_chk[yy_base[yy_current_state] + yy_c] != yy_current_state )
 		{
 		yy_current_state = (int) yy_def[yy_current_state];
-		if ( yy_current_state >= 105 )
+		if ( yy_current_state >= 112 )
 			yy_c = yy_meta[yy_c];
 		}
 	yy_current_state = yy_nxt[yy_base[yy_current_state] + yy_c];
-	yy_is_jam = (yy_current_state == 104);
+	yy_is_jam = (yy_current_state == 111);
 
 	(void)yyg;
 	return yy_is_jam ? 0 : yy_current_state;
@@ -2593,7 +2638,7 @@ void yyfree (void * ptr , yyscan_t yyscanner)
 
 #define YYTABLES_NAME "yytables"
 
-#line 205 "scanner.l"
+#line 218 "scanner.l"
 
 
 void *libconfig_yyalloc(size_t bytes, void *yyscanner)

--- a/lib/scanner.h
+++ b/lib/scanner.h
@@ -714,7 +714,7 @@ extern int yylex \
 #undef yyTABLES_NAME
 #endif
 
-#line 205 "scanner.l"
+#line 218 "scanner.l"
 
 
 #line 720 "scanner.h"

--- a/lib/scanner.h
+++ b/lib/scanner.h
@@ -714,7 +714,7 @@ extern int yylex \
 #undef yyTABLES_NAME
 #endif
 
-#line 218 "scanner.l"
+#line 256 "scanner.l"
 
 
 #line 720 "scanner.h"

--- a/lib/scanner.l
+++ b/lib/scanner.l
@@ -143,7 +143,7 @@ include_open ^[ \t]*@include[ \t]+\"
 {float}           { yylval->fval = atof(yytext); return(TOK_FLOAT); }
 {integer}         {
                     int ok;
-                    long long llval = libconfig_parse_integer(yytext, &ok);
+                    long long llval = libconfig_parse_integer(yytext, &ok,0);
                     if(!ok)
                       return(TOK_ERROR);
 
@@ -158,22 +158,60 @@ include_open ^[ \t]*@include[ \t]+\"
                       return(TOK_INTEGER);
                     }
                   }
-{integer64}       { yylval->llval = atoll(yytext); return(TOK_INTEGER64); }
-{bin}             {
-                    yylval->ival = strtoul(yytext+2, NULL,2);
-                    return(TOK_BIN);
+{integer64}       {
+                    int ok;
+                    long long llval = libconfig_parse_integer(yytext,&ok,1);
+                    if (!ok)
+                      return (TOK_ERROR);
+
+                    yylval->llval = llval;
+                    return(TOK_INTEGER64);
                   }
-{bin64}           {
-                    yylval->llval = libconfig_parse_bin64(yytext);
+{bin}             {
+                    int ok;
+                    unsigned long long llval = libconfig_parse_bin64(yytext,&ok,0);
+                    if (!ok)
+                      return (TOK_ERROR);
+
+                    if (llval < INT_MAX)
+                    {
+                      yylval->ival = (int) llval;
+                      return TOK_BIN;
+                    }
+
+                    yylval->llval = llval;
                     return(TOK_BIN64);
                   }
+{bin64}           {
+                    int ok;
+                    unsigned long long llval = libconfig_parse_bin64(yytext,&ok,1);
+                    if (!ok)
+                      return (TOK_ERROR);
+                    yylval->llval = llval;
+                    return (TOK_BIN64);
+                  }
 {hex}             {
-                    yylval->ival = strtoul(yytext, NULL, 16);
-                    return(TOK_HEX);
+                    int ok;
+                    unsigned long long llval = libconfig_parse_hex64(yytext,&ok,0);
+                    if (!ok)
+                      return (TOK_ERROR);
+
+                    if (llval < INT_MAX)
+                    {
+                      yylval->ival = (int) llval;
+                      return TOK_HEX;
+                    }
+
+                    yylval->llval = llval;
+                    return(TOK_HEX64);
                   }
 {hex64}           {
-                    yylval->llval = libconfig_parse_hex64(yytext);
-                    return(TOK_HEX64);
+                    int ok;
+                    unsigned long long llval = libconfig_parse_hex64(yytext,&ok,1);
+                    if (!ok)
+                      return (TOK_ERROR);
+                    yylval->llval = llval;
+                    return (TOK_HEX64);
                   }
 \[                { return(TOK_ARRAY_START); }
 \]                { return(TOK_ARRAY_END); }

--- a/lib/scanner.l
+++ b/lib/scanner.l
@@ -60,6 +60,8 @@ false             [Ff][Aa][Ll][Ss][Ee]
 name              [A-Za-z\*][-A-Za-z0-9_\*]*
 integer           [-+]?[0-9]+
 integer64         [-+]?[0-9]+L(L)?
+bin               0[bB][01]+
+bin64             0[bB][01]+L(L)?
 hex               0[Xx][0-9A-Fa-f]+
 hex64             0[Xx][0-9A-Fa-f]+L(L)?
 hexchar           \\[Xx][0-9A-Fa-f]{2}
@@ -157,6 +159,14 @@ include_open ^[ \t]*@include[ \t]+\"
                     }
                   }
 {integer64}       { yylval->llval = atoll(yytext); return(TOK_INTEGER64); }
+{bin}             {
+                    yylval->ival = strtoul(yytext+2, NULL,2);
+                    return(TOK_BIN);
+                  }
+{bin64}           {
+                    yylval->llval = libconfig_parse_bin64(yytext);
+                    return(TOK_BIN64);
+                  }
 {hex}             {
                     yylval->ival = strtoul(yytext, NULL, 16);
                     return(TOK_HEX);

--- a/lib/util.c
+++ b/lib/util.c
@@ -232,7 +232,7 @@ static int clzl(int64_t val)
   while (!(val & check) && check)
   {
     leading++;
-    check >>=1;
+    check >>= 1;
   }
   return leading;
 }
@@ -243,11 +243,11 @@ void libconfig_format_bin(int64_t val, char *buf, size_t buflen)
   /* find number of leading 0's */
   unsigned c = clzl(val);
   unsigned i = 0;
-  while ( (c < 64) && (i < buflen -1) )
+  while ( (c < 64) && (i < buflen - 1) )
   {
-    buf[i] = (val & ( 1ll << (63-c))) ? '1' : '0';
+    buf[i] = (val & (1ll << (63 - c))) ? '1' : '0';
     i++;
     c++;
   }
-  buf[i]=0;
+  buf[i] = 0;
 }

--- a/lib/util.h
+++ b/lib/util.h
@@ -35,9 +35,9 @@ extern void *libconfig_realloc(void *ptr, size_t size);
 #define __delete(P) free((void *)(P))
 #define __zero(P) memset((void *)(P), 0, sizeof(*P))
 
-extern long long libconfig_parse_integer(const char *s, int *ok);
-extern unsigned long long libconfig_parse_hex64(const char *s);
-extern unsigned long long libconfig_parse_bin64(const char *s);
+extern long long libconfig_parse_integer(const char *s, int *ok, int L_ok);
+extern unsigned long long libconfig_parse_hex64(const char *s, int *ok, int L_ok);
+extern unsigned long long libconfig_parse_bin64(const char *s, int *ok, int L_ok);
 
 extern void libconfig_format_double(double val, int precision, int sci_ok,
                                     char *buf, size_t buflen);

--- a/lib/util.h
+++ b/lib/util.h
@@ -37,7 +37,8 @@ extern void *libconfig_realloc(void *ptr, size_t size);
 
 extern long long libconfig_parse_integer(const char *s, int *ok);
 extern unsigned long long libconfig_parse_hex64(const char *s);
+extern unsigned long long libconfig_parse_bin64(const char *s);
 
 extern void libconfig_format_double(double val, int precision, int sci_ok,
                                     char *buf, size_t buflen);
-
+extern void libconfig_format_bin(int64_t val, char *buf, size_t buflen);

--- a/tests/testdata/binhex.cfg
+++ b/tests/testdata/binhex.cfg
@@ -1,0 +1,7 @@
+regular_int = 12;
+regular_bigint = 10000000000L;
+hex_int = 0x20;
+hex_bigint = 0x1FFFFFFFFL;
+bin_int = 0b1111;
+bin_bigint = 0b100001000010000010000100001L;
+mixed = [ 1, 0x2, 0b11 ];

--- a/tests/tests.c
+++ b/tests/tests.c
@@ -664,6 +664,40 @@ TT_TEST(ReadStream)
 
 /* ------------------------------------------------------------------------- */
 
+TT_TEST(BinaryAndHex)
+{
+  char *buf;
+  config_t cfg;
+  int rc;
+  int ival;
+  long long llval;
+
+
+  config_init(&cfg);
+
+  buf = "somebin=0b1010101;\nsomehex=0xbeef;\nsomebighex=0x100000000L;\nsomebigbin=0b111111111111111111111111111111111L; ";
+  rc = config_read_string(&cfg, buf);
+  TT_ASSERT_TRUE(rc);
+  rc = config_lookup_int(&cfg,"somebin",&ival);
+  TT_ASSERT_TRUE(rc);
+  TT_ASSERT_INT_EQ(ival, 85);
+  rc = config_lookup_int(&cfg,"somehex",&ival);
+  TT_ASSERT_TRUE(rc);
+  TT_ASSERT_INT_EQ(ival, 48879);
+  rc = config_lookup_int64(&cfg,"somebighex",&llval);
+  TT_ASSERT_TRUE(rc);
+  TT_ASSERT_INT64_EQ(llval, 0x100000000LL);
+  rc = config_lookup_int64(&cfg,"somebigbin",&llval);
+  TT_ASSERT_TRUE(rc);
+  TT_ASSERT_INT64_EQ(llval, 0x1ffffffffLL);
+
+  parse_and_compare("./testdata/binhex.cfg", "./testdata/binhex.cfg");
+
+
+}
+
+/* ------------------------------------------------------------------------- */
+
 int main(int argc, char **argv)
 {
   int failures;
@@ -684,6 +718,7 @@ int main(int argc, char **argv)
   TT_SUITE_TEST(LibConfigTests, OverrideSetting);
   TT_SUITE_TEST(LibConfigTests, SettingLookups);
   TT_SUITE_TEST(LibConfigTests, ReadStream);
+  TT_SUITE_TEST(LibConfigTests, BinaryAndHex);
   TT_SUITE_RUN(LibConfigTests);
   failures = TT_SUITE_NUM_FAILURES(LibConfigTests);
   TT_SUITE_END(LibConfigTests);

--- a/tests/tests.c
+++ b/tests/tests.c
@@ -675,7 +675,12 @@ TT_TEST(BinaryAndHex)
 
   config_init(&cfg);
 
-  buf = "somebin=0b1010101;\nsomehex=0xbeef;\nsomebighex=0x100000000L;\nsomebigbin=0b111111111111111111111111111111111L; ";
+  buf = "somebin=0b1010101;\n"
+        "somehex=0xbeef;\n"
+        "someautobighex=0x100000000;\n"
+        "someautobigbin=0b111111111111111111111111111111111;"
+        "somebighex=0x100000000L;\n"
+        "somebigbin=0b111111111111111111111111111111111L;";
   rc = config_read_string(&cfg, buf);
   TT_ASSERT_TRUE(rc);
   rc = config_lookup_int(&cfg,"somebin",&ival);
@@ -684,6 +689,12 @@ TT_TEST(BinaryAndHex)
   rc = config_lookup_int(&cfg,"somehex",&ival);
   TT_ASSERT_TRUE(rc);
   TT_ASSERT_INT_EQ(ival, 48879);
+  rc = config_lookup_int64(&cfg,"someautobighex",&llval);
+  TT_ASSERT_TRUE(rc);
+  TT_ASSERT_INT64_EQ(llval, 0x100000000LL);
+  rc = config_lookup_int64(&cfg,"someautobigbin",&llval);
+  TT_ASSERT_TRUE(rc);
+  TT_ASSERT_INT64_EQ(llval, 0x1ffffffffLL);
   rc = config_lookup_int64(&cfg,"somebighex",&llval);
   TT_ASSERT_TRUE(rc);
   TT_ASSERT_INT64_EQ(llval, 0x100000000LL);


### PR DESCRIPTION
This  adds support for binary integers to the libconfig grammar, specified by a 0b or 0B prefix. These are treated very similarly to how hex integers are treated (including defining an integer format for them so they may be output, and having an L suffix for 64-bit integers). One might accuse me of grepping for hex and then doing the same thing for binary... 

A few salient points: 
 - This isn't using the %b format specifier for output that is supported by newer glibc, instead writing a custom formatter. This is because I don't know how widespread or portable this is (I think it's party of a new C standard?). 
 - I added a test, which tests both binary and hex together (since the implementation is quite parallel)
 - It could be possible to automatically detect binary (and hex, for that matter) that doesn't fit in 32 bits using the grammar, but I didn't implement that.
 - I haven't updated any documentation, but I can do that if this is accepted. 
 