### PR TITLE
cmake: Fix "deprecated version compatibility" warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.1...3.28)
 
 # Extract version from configure.ac.
 set(VERSION_REGEX "^AC_INIT\\(\\[libconfig\\],[ \t]*\\[([0-9.]+)\\],.*")


### PR DESCRIPTION
  - Add version `...<max>` suffix to mark that the project does not need compatibility with older versions

PR for issue: #239

No practical difference in build, project builds&compiles fine with updated CMake but without odd compatibility warning.

The fix should be compatible with CMake < 3.12 as per [docs](https://cmake.org/cmake/help/latest/command/cmake_minimum_required.html#:~:text=If%20the%20running%20version%20of%20CMake%20is%20older%20than%203.12%2C%20the%20extra%20...%20dots%20will%20be%20seen%20as%20version%20component%20separators%2C%20resulting%20in%20the%20...%3Cmax%3E%20part%20being%20ignored%20and%20preserving%20the%20pre%2D3.12%20behavior%20of%20basing%20policies%20on%20%3Cmin%3E):
> If the running version of CMake is older than 3.12, the extra ... dots will be seen as version component separators, resulting in the `...<max> part being ignored` and preserving the pre-3.12 behavior of basing policies on <min>.