### PR TITLE
cmake: Fix broken static library build for c++ target

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -62,7 +62,7 @@ if(BUILD_SHARED_LIBS)
     target_compile_definitions(${libname}++ PRIVATE LIBCONFIG_STATIC)
 else()
     target_compile_definitions(${libname} PUBLIC LIBCONFIG_STATIC)
-    target_compile_definitions(${libname}++ PUBLIC LIBCONFIGXX_STATIC)
+    target_compile_definitions(${libname}++ PUBLIC LIBCONFIG_STATIC LIBCONFIGXX_STATIC)
 endif()
 
 if(APPLE)


### PR DESCRIPTION
PR for issue: #237

If you try to build C++ target with `option(BUILD_SHARED_LIBS  "Enable shared library"` **OFF**`)` - it will fail coz C code being built in shared-lib manner, due to missing `LIBCONFIG_STATIC` definition.

This is the fix.