### PR TITLE
Make WriteFile const so constant objects can write their contents

### DIFF
--- a/lib/libconfig.h++
+++ b/lib/libconfig.h++
@@ -516,8 +516,8 @@ class LIBCONFIGXX_API Config
   inline void readFile(const std::string &filename)
   { readFile(filename.c_str()); }
 
-  void writeFile(const char *filename);
-  inline void writeFile(const std::string &filename)
+  void writeFile(const char *filename) const;
+  inline void writeFile(const std::string &filename) const
   { writeFile(filename.c_str()); }
 
   Setting & lookup(const char *path) const;

--- a/lib/libconfigcpp.c++
+++ b/lib/libconfigcpp.c++
@@ -521,7 +521,7 @@ void Config::readFile(const char *filename)
 
 // ---------------------------------------------------------------------------
 
-void Config::writeFile(const char *filename)
+void Config::writeFile(const char *filename) const
 {
   if(! config_write_file(_config, filename))
     handleError();


### PR DESCRIPTION
Currently only Write method is const but not WriteFile so it can not be used with const objects