### PR TITLE
cmake: build pkgconfig files

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -148,3 +148,21 @@ install(FILES
     "${CMAKE_CURRENT_BINARY_DIR}/libconfigConfigVersion.cmake"
     DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/libconfig"
     )
+
+if (UNIX)
+    configure_file(
+        ${CMAKE_CURRENT_SOURCE_DIR}/libconfig.pc.cmake.in
+        ${CMAKE_CURRENT_BINARY_DIR}/libconfig.pc @ONLY
+        )
+
+    configure_file(
+        ${CMAKE_CURRENT_SOURCE_DIR}/libconfig++.pc.cmake.in
+        ${CMAKE_CURRENT_BINARY_DIR}/libconfig++.pc @ONLY
+        )
+
+    install(FILES
+        ${CMAKE_CURRENT_BINARY_DIR}/libconfig.pc
+        ${CMAKE_CURRENT_BINARY_DIR}/libconfig++.pc
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig
+        )
+endif (UNIX)

--- a/lib/libconfig++.pc.cmake.in
+++ b/lib/libconfig++.pc.cmake.in
@@ -1,0 +1,12 @@
+libdir=@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_LIBDIR@
+includedir=@CMAKE_INSTALL_PREFIX@/include
+
+Name: libconfig++
+Description: C++ Configuration File Library
+Version: @PROJECT_VERSION@
+URL: http://www.hyperrealm.com/main.php?s=libconfig
+Requires:
+Conflicts:
+Libs: -L${libdir} -lconfig++
+Libs.private:
+Cflags: -I${includedir}

--- a/lib/libconfig.pc.cmake.in
+++ b/lib/libconfig.pc.cmake.in
@@ -1,0 +1,12 @@
+libdir=@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_LIBDIR@
+includedir=@CMAKE_INSTALL_PREFIX@/include
+
+Name: libconfig
+Description: C Configuration File Library
+Version: @PROJECT_VERSION@
+URL: http://www.hyperrealm.com/main.php?s=libconfig
+Requires:
+Conflicts:
+Libs: -L${libdir} -lconfig
+Libs.private:
+Cflags: -I${includedir}


### PR DESCRIPTION
Include the build of the pkgconfig files (as required by shairport-sync for example.)

updated to limit the pkgconfig creation to UNIX