### PR TITLE
Please include stdint.h for MSVC

### DIFF
--- a/lib/util.h
+++ b/lib/util.h
@@ -21,6 +21,7 @@
 */
 
 #include <string.h>
+#include <stdint.h>
 #include <sys/types.h>
 
 extern void libconfig_set_fatal_error_func(void (*func)(const char *));


### PR DESCRIPTION
I met compilation error on MSVC while building libconfig 1.8.
This PR tries to fix it.

```
C:\PROGRA~1\MICROS~1\2022\ENTERP~1\VC\Tools\MSVC\1443~1.348\bin\Hostx64\x64\cl.exe   -DLIBCONFIGXX_EXPORTS -DLIBCONFIG_STATIC -DYY_NO_UNISTD_H -DYY_USE_CONST -D_CRT_SECURE_NO_DEPRECATE -Ilib /nologo /DWIN32 /D_WINDOWS /utf-8 /MP  /MDd /Z7 /Ob0 /Od /RTC1  -MDd /showIncludes /Folib\CMakeFiles\libconfig++.dir\strbuf.c.obj /Fdlib\CMakeFiles\libconfig++.dir\ /FS -c lib\strbuf.c
lib\util.h(46): error C2146: syntax error: missing ')' before identifier 'val'
lib\util.h(46): error C2061: syntax error: identifier 'val'
lib\util.h(46): error C2059: syntax error: ';'
lib\util.h(46): error C2059: syntax error: ','
lib\util.h(46): error C2059: syntax error: ')'
```
