### PR TITLE
libconfig_format_bin: fix on 32-bit systems

### DIFF
--- a/lib/util.c
+++ b/lib/util.c
@@ -286,7 +286,7 @@ void libconfig_format_double(double val, int precision, int sci_ok, char *buf,
 /* ------------------------------------------------------------------------- */
 
 #ifdef __GNUC__
-#define clzl(x) __builtin_clzl(x)
+#define clzl(x) __builtin_clzll(x)
 #else
 static int clzl(int64_t val)
 {


### PR DESCRIPTION
Before the change conversion of bin produced wrong leading zeros and failed test son `i686-linux` as:

    [TEST] BinaryAndHex
    files "temp.cfg" and "./testdata/binhex.cfg" differ starting at line 5, char 12
    tests.c:55: failed assert: ("temp.cfg") ["temp.cfg"] ==txtfile (output_file) ["./testdata/binhex.cfg"]
    [FAIL] BinaryAndHex

If fails because the output contains extra leading zeros:

    --- ./tests/temp.cfg    2025-05-01 19:33:38.094444650 +0100
    +++ ./tests/testdata/binhex.cfg 2025-05-01 14:08:07.152539477 +0100
    @@ -2,6 +2,6 @@
     regular_bigint = 10000000000L;
     hex_int = 0x20;
     hex_bigint = 0x1FFFFFFFFL;
    -bin_int = 0b000000000000000000000000000000001111;
    -bin_bigint = 0b00000000000000000000000000000000100001000010000010000100001L;
    -mixed = [ 1, 0x2, 0b0000000000000000000000000000000011 ];
    +bin_int = 0b1111;
    +bin_bigint = 0b100001000010000010000100001L;
    +mixed = [ 1, 0x2, 0b11 ];

This happens because used `int __builtin_clzl (unsigned long)` operates on 32-bit `long` values.

The fix uses `int __builtin_clzll (unsigned long long)` to fit in 64-bit values.

Closes: https://github.com/hyperrealm/libconfig/issues/259