### PR TITLE
Fixes to failing windows MSVC compiling #269 

### DIFF
--- a/lib/libconfig.c
+++ b/lib/libconfig.c
@@ -115,7 +115,7 @@ static void __config_locale_override(void)
 
 #else
 
-#warning "No way to modify calling thread's locale!"
+#pragma warning "No way to modify calling thread's locale!"
 
 #endif
 }
@@ -135,7 +135,7 @@ static void __config_locale_restore(void)
 
 #else
 
-#warning "No way to modify calling thread's locale!"
+#pragma warning "No way to modify calling thread's locale!"
 
 #endif
 }

--- a/lib/wincompat.h
+++ b/lib/wincompat.h
@@ -31,7 +31,7 @@
 
 #define LIBCONFIG_WINDOWS_OS
 
-if defined(__MINGW32__) || defined(__MINGW64__)
+#if defined(__MINGW32__) || defined(__MINGW64__)
 #define LIBCONFIG_MINGW_OS
 #endif
 
@@ -120,7 +120,7 @@ extern int posix_fsync(int fd);
 
 #else /* defined(LIBCONFIG_WINDOWS_OS) && !defined(LIBCONFIG_MINGW_OS) */
 
-#include <unistd.h> /* for fsync() */
+//#include <unistd.h> /* for fsync() */
 
 #define posix_fileno fileno
 #define posix_fsync  fsync
@@ -132,6 +132,9 @@ extern int posix_fsync(int fd);
 #define IS_RELATIVE_PATH(P) \
   ((P)[0] != '/')
 
+
 #endif /* defined(LIBCONFIG_WINDOWS_OS) && !defined(LIBCONFIG_MINGW_OS) */
+
+#endif /* defined(WIN32) || defined(_WIN32) || defined(__WIN32__) || defined(WIN64) || defined(_WIN64) || defined(__WIN64__) */
 
 #endif /* __wincompat_h */


### PR DESCRIPTION
This is a merge request with the fixes that were preventing MSVC from compiling libconfig and libconfig++

In relation to the discovery and fixes associated with issue #269 

---

> While looking into this I found a few issues that I initially thought might've been my fault with an accidental delete but indeed its in the master branch.
> 
> [libconfig/lib/wincompat.h](https://github.com/hyperrealm/libconfig/blob/dedaae8792ca234a8275d72f59222cea0195cd21/lib/wincompat.h#L33-L37)
> 
> Lines 33 to 37 in [dedaae8](/hyperrealm/libconfig/commit/dedaae8792ca234a8275d72f59222cea0195cd21)
> 
>   
>  if defined(__MINGW32__) || defined(__MINGW64__) 
>  #define LIBCONFIG_MINGW_OS 
>  #endif 
>   
> The `if defined(__MINGW32__) || defined(__MINGW64__)` is missing a `#`

