### PR TITLE
Add missing dependency for scanner.h

### DIFF
--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -36,6 +36,9 @@ libinc_cpp =  libconfig.h++
 
 BUILT_SOURCES = scanner.c scanner.h grammar.c grammar.h
 
+scanner.h: scanner.c
+	@if test ! -f $@; then rm -f scanner.c; $(MAKE) $(AM_MAKEFLAGS) scanner.c; else :; fi
+
 ## Build mode: C-only or C & C++
 lib_LTLIBRARIES = libconfig.la
 


### PR DESCRIPTION
Automake doesn't handle the header -> source dependency for lex scanners. This might result in the out-of-date header or it not being rebuilt in time. Provide a rule to make sure that the header is built properly.