### PR TITLE
CMakeLists.txt: bump minimum CMake version to 3.10

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1...3.28)
+cmake_minimum_required(VERSION 3.10)
 
 # Extract version from configure.ac.
 set(VERSION_REGEX "^AC_INIT\\(\\[libconfig\\],[ \t]*\\[([0-9.]+)\\],.*")


### PR DESCRIPTION
This bump fixes the following compatibility issue with CMake 4.x:

```
| Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax 
| to tell CMake that the project requires at least <min> but has been updated 
| to work with policies introduced by <max> or earlier. 
| Or, add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway.

| -- Configuring incomplete, errors occurred!

libconfig| CMake configuration: FAILED
```

Fixes https://github.com/hyperrealm/libconfig/issues/275