### PR TITLE
build.yaml: enable tests

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -12,7 +12,10 @@ jobs:
           architecture: 'x64'
       # install dependencies
       - name: CMake build
-        run: cmake -B build && cmake --build build
+        run: |
+          cmake -B build
+          cmake --build build
+          ctest -V --test-dir build -C Debug
 
       - name: autoconf build
         if: ${{ matrix.os == 'ubuntu-latest' }}
@@ -21,3 +24,4 @@ jobs:
           ./configure
           make clean
           make
+          make test

--- a/tests/tests.c
+++ b/tests/tests.c
@@ -121,7 +121,7 @@ static const char *read_file_to_string(const char *file)
   buf = (char *)malloc(size + 1);
   TT_ASSERT_PTR_NOTNULL(buf);
 
-  fp = fopen(file, "rt");
+  fp = fopen(file, "rb");
   TT_ASSERT_PTR_NOTNULL(fp);
 
   r = fread(buf, 1, size, fp);


### PR DESCRIPTION
Execute tests for both CMake and autoconf build systems.