### PR TITLE
fuzz: fix off-by-one stack overflow in fuzz_config_read

### DIFF
--- a/fuzz/fuzz_config_read.c
+++ b/fuzz/fuzz_config_read.c
@@ -8,7 +8,7 @@
 #define MAX_CONFIG_SIZE 4096
 #define MAX_PATH_SIZE 256
 #define MIN_BUFF_SIZE sizeof(fuzz_data_t) + 2 // Room for fixed-width data and two null terminators
-#define MAX_BUFF_SIZE sizeof(fuzz_data_t) + MAX_CONFIG_SIZE + MAX_PATH_SIZE + 1
+#define MAX_BUFF_SIZE sizeof(fuzz_data_t) + MAX_CONFIG_SIZE + MAX_PATH_SIZE + 2
 
 // Forward-declare the libFuzzer's mutator callback.
 extern size_t LLVMFuzzerMutate(uint8_t *Data, size_t Size, size_t MaxSize);


### PR DESCRIPTION
The `MAX_BUFF_SIZE` macro was undersized by one byte, leading to a 1-byte stack-buffer-overflow when the fuzzer processed inputs with maximum allowed `content_size` and `path_size`.

The fuzzer harness requires space for a header, the config content, the file path, and two null terminators (one for the content and one for the path). The memory layout is:
`[fuzz_data_t] [content] [\0] [path] [\0]`

With the previous definition:
`sizeof(fuzz_data_t) (9) + MAX_CONFIG_SIZE (4096) + MAX_PATH_SIZE (256) + 1 = 4362`

When both sizes are at their maximum, the harness attempts to write the final null terminator at index 4362 (`9 + 4096 + 1 + 256`). In a buffer of size 4362, index 4362 is out of bounds.

This patch increases `MAX_BUFF_SIZE` to account for both null terminators, bringing the total size to 4363 and ensuring the final write is within bounds.

Co-authored-by:  CodeMender <codemender-patching@google.com>
Fixes: https://issues.oss-fuzz.com/issues/471519948