### PR TITLE
Ruby: Add "compile" Rake task for libconfig-ruby

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ temp
 *.user
 *.userosscache
 *.sln.docstates
+/contrib/libconfig-ruby/Gemfile.lock
+/contrib/libconfig-ruby/lib/rconfig.so
+/contrib/libconfig-ruby/tmp/

--- a/contrib/libconfig-ruby/Gemfile
+++ b/contrib/libconfig-ruby/Gemfile
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+gem "rake-compiler", "~> 1.3"

--- a/contrib/libconfig-ruby/Rakefile
+++ b/contrib/libconfig-ruby/Rakefile
@@ -8,7 +8,7 @@ spec = Gem::Specification.new do |s|
   s.email = "whitequark@whitequark.ru"
   s.platform = Gem::Platform::RUBY
   s.summary = "libconfig bindings"
-  s.files = [ File.join('ext', 'extconf.rb'), File.join('ext', 'rconfig.c') ].to_a
+  s.files = [ File.join('ext', 'extconf.rb'), File.join('ext', 'rconfig.c') ]
   s.extensions = 'ext/extconf.rb'
 end
  

--- a/contrib/libconfig-ruby/Rakefile
+++ b/contrib/libconfig-ruby/Rakefile
@@ -15,3 +15,10 @@ end
 Gem::PackageTask.new(spec) do |pkg|
 end
  
+require 'rake/extensiontask'
+
+task build: :compile
+
+Rake::ExtensionTask.new("rconfig") do |ext|
+  ext.ext_dir = 'ext'
+end


### PR DESCRIPTION
Hello,

This adds `compile` Rake task for `contrib/libconfig-ruby` with commonly used Rake Compiler.  This makes native compilation of the gem easier.

Thank you,